### PR TITLE
ajout de authentificaton ENSAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # ophirofox ![icône Ophirofox](https://raw.githubusercontent.com/lovasoa/ophirofox/master/ophirofox/icons/48.png) 
-Une extension pour navigateurs qui permet de lire les articles du **Monde**, du **Figaro**, et de **Libération** sur son compte [**Europresse ENS**](http://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1).
+
+Une extension pour navigateurs qui permet de lire les articles du **Monde**, du **Figaro**, et de **Libération** sur son compte **Europresse**.
 
 [![Mozilla Firefox: download on mozilla addons](https://user-images.githubusercontent.com/552629/82738693-f4900f80-9d39-11ea-816c-1bddb73b6967.png)](https://github.com/lovasoa/ophirofox/releases/latest/download/ophirofox.xpi)
 [![Google Chrome: download on the chrome web store](https://user-images.githubusercontent.com/552629/104166652-661ceb00-53fb-11eb-91c1-2db0718db66f.png)](https://chrome.google.com/webstore/detail/ophirofox/mmmjkgckgcpankonbgbianpnfenbhodf)
 
 L'extension ajoute un bouton *Lire sur Europresse* sur les articles réservés aux abonnés du [monde.fr](https://www.lemonde.fr/) et d'autres sites d'information.
-Ce bouton vous permet de vous connecter avec votre compte sur [sso.ens.fr](https://sso.ens.fr/cas/login), et une fois authentifié,
+Ce bouton vous permet de vous connecter avec votre compte sur europresse via le site de votre université, et une fois authentifié,
 d'être redirigé automatiquement vers une page de recherche europresse qui contient l'article du Monde original.
 
 ![Capture d'écran animée de démonstration de l'extension](https://user-images.githubusercontent.com/552629/93182919-98168d00-f73a-11ea-9518-175847fdc677.gif)
 
+
+## Partenaires Europresse supportés
+
+L'extension fonctionne avec les portails universitaires suivants :
+ - [**Europresse ENS Ulm PSL**](http://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1),
+ - [**Europresse ENSAM (Arts et Métiers)**](http://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML).
 
 ## Sites supportés
   - [Le Monde](https://www.lemonde.fr/)
@@ -54,3 +61,8 @@ et lancer une recherche europresse.
 
 Cette extension est un logiciel libre sous license [MPL](https://github.com/lovasoa/ophirofox/blob/master/LICENSE).
 Vous pouvez y contribuer [sur github](https://github.com/lovasoa/ophirofox).
+
+Si vous avez accès à un portail europresse via votre université mais qu'il n'est pas supporté par cette extension,
+il devrait être relativement facile à ajouter.
+N'hésitez pas à [ouvrir une demande sur Github](https://github.com/lovasoa/ophirofox/issues/new),
+ou à ajouter vous-même le support pour votre université en modifiant [`config.js`](./ophirofox/content_scripts/config.js) 

--- a/ophirofox/background.js
+++ b/ophirofox/background.js
@@ -1,0 +1,5 @@
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === "install") {
+    chrome.runtime.openOptionsPage();
+  }
+});

--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -1,0 +1,68 @@
+const ophirofox_config_list = [
+  class OphirofoxConfigULM {
+    static domains = ["ens.fr"];
+    static LOGIN_URL = "http://proxy.rubens.ens.fr/login";
+    static AUTH_URL = // URL à charger pour pouvoir se logger sans mot de passe
+      "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
+  },
+  class OphirofoxConfigENSAM {
+    static domains = ["ensam.eu"];
+    static LOGIN_URL = "http://rp1.ensam.eu/login";
+    static AUTH_URL =
+      "https://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
+  },
+];
+
+/**
+ * Get the config for a given domain
+ * @param {string} domain
+ */
+function getOphirofoxConfigByDomain(domain) {
+  return ophirofox_config_list.find(({ domains }) => domains.includes(domain));
+}
+
+async function getStorage(key) {
+  return new Promise((accept, reject) => {
+    chrome.storage.local.get([key], function (result) {
+      if (result.hasOwnProperty(key)) accept(result[key]);
+      else
+        reject(
+          new Error(
+            `Key ${key} not found in extension storage: ${chrome.runtime.lastError}`
+          )
+        );
+    });
+  });
+}
+
+async function getOphirofoxConfig() {
+  const url = new URL(window.location);
+  const domain = url.host.split(".").slice(-2).join(".");
+  // Si la page actuelle est spécifique à une configuration, alors on l'utilise
+  let domain_match = getOphirofoxConfigByDomain(domain);
+  if (domain_match) return domain_match;
+  try {
+    const default_domain = await getStorage("ophirofox_default_domain");
+    domain_match = getOphirofoxConfigByDomain(default_domain);
+    if (domain_match) return domain_match;
+  } catch (err) {
+    const fallback = ophirofox_config_list[0];
+    console.warn(`No ophirofox domain found, using the default ${fallback.domains[0]}: ${err}`);
+    return fallback;
+  }
+}
+
+const ophirofox_config = getOphirofoxConfig();
+
+/**
+ * Crée un lien vers une recherche europresse pré-remplie avec les termes de recherche passés en argument
+ * @param {string} keywords
+ * @returns {URL}
+ */
+async function makeOphirofoxReadingLink(keywords) {
+  const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
+  target_url.searchParams.set("ophirofox_source", window.location);
+  target_url.searchParams.set("ophirofox_keywords", keywords);
+  const config = await ophirofox_config;
+  return new URL(`${config.LOGIN_URL}?url=${target_url}`);
+}

--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -1,11 +1,13 @@
 const ophirofox_config_list = [
   class OphirofoxConfigULM {
+    static name = "ULM";
     static domains = ["ens.fr"];
     static LOGIN_URL = "http://proxy.rubens.ens.fr/login";
     static AUTH_URL = // URL à charger pour pouvoir se logger sans mot de passe
       "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
   },
   class OphirofoxConfigENSAM {
+    static name = "ENSAM";
     static domains = ["ensam.eu"];
     static LOGIN_URL = "http://rp1.ensam.eu/login";
     static AUTH_URL =
@@ -21,17 +23,49 @@ function getOphirofoxConfigByDomain(domain) {
   return ophirofox_config_list.find(({ domains }) => domains.includes(domain));
 }
 
-async function getStorage(key) {
-  return new Promise((accept, reject) => {
+/**
+ * Get the config with the given name
+ * @param {string} search_name
+ */
+function getOphirofoxConfigByName(search_name) {
+  return ophirofox_config_list.find(({ name }) => search_name === name);
+}
+
+const DEFAULT_SETTINGS = {
+  partner_name: "ULM",
+};
+
+const OPHIROFOX_SETTINGS_KEY = "ophirofox_settings";
+
+/**
+ * @returns {Promise<typeof DEFAULT_SETTINGS>}
+ */
+async function getSettings() {
+  const key = OPHIROFOX_SETTINGS_KEY;
+  return new Promise((accept) => {
     chrome.storage.local.get([key], function (result) {
-      if (result.hasOwnProperty(key)) accept(result[key]);
-      else
-        reject(
+      if (result.hasOwnProperty(key)) accept(JSON.parse(result[key]));
+      else {
+        console.error(
           new Error(
             `Key ${key} not found in extension storage: ${chrome.runtime.lastError}`
           )
         );
+        accept(DEFAULT_SETTINGS);
+      }
     });
+  });
+}
+
+/**
+ * @param {typeof DEFAULT_SETTINGS} settings
+ */
+async function setSettings(settings) {
+  return new Promise((accept) => {
+    chrome.storage.local.set(
+      { [OPHIROFOX_SETTINGS_KEY]: JSON.stringify(settings) },
+      accept
+    );
   });
 }
 
@@ -39,17 +73,19 @@ async function getOphirofoxConfig() {
   const url = new URL(window.location);
   const domain = url.host.split(".").slice(-2).join(".");
   // Si la page actuelle est spécifique à une configuration, alors on l'utilise
-  let domain_match = getOphirofoxConfigByDomain(domain);
+  const domain_match = getOphirofoxConfigByDomain(domain);
   if (domain_match) return domain_match;
   try {
-    const default_domain = await getStorage("ophirofox_default_domain");
-    domain_match = getOphirofoxConfigByDomain(default_domain);
-    if (domain_match) return domain_match;
+    const { partner_name } = await getSettings();
+    const name_match = getOphirofoxConfigByName(partner_name);
+    if (name_match) return name_match;
   } catch (err) {
-    const fallback = ophirofox_config_list[0];
-    console.warn(`No ophirofox domain found, using the default ${fallback.domains[0]}: ${err}`);
-    return fallback;
+    console.warn(
+      `No ophirofox domain found, using the default ${fallback.name}: ${err}`
+    );
   }
+  const fallback = ophirofox_config_list[0];
+  return fallback;
 }
 
 const ophirofox_config = getOphirofoxConfig();
@@ -66,3 +102,11 @@ async function makeOphirofoxReadingLink(keywords) {
   const config = await ophirofox_config;
   return new URL(`${config.LOGIN_URL}?url=${target_url}`);
 }
+
+export {
+  ophirofox_config_list,
+  ophirofox_config,
+  makeOphirofoxReadingLink,
+  getSettings,
+  setSettings,
+};

--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -103,10 +103,12 @@ async function makeOphirofoxReadingLink(keywords) {
   return new URL(`${config.LOGIN_URL}?url=${target_url}`);
 }
 
-export {
-  ophirofox_config_list,
-  ophirofox_config,
-  makeOphirofoxReadingLink,
-  getSettings,
-  setSettings,
-};
+if (window.location.protocol.includes("extension")) {
+  window.ophirofox_config_exports = {
+    ophirofox_config_list,
+    ophirofox_config,
+    makeOphirofoxReadingLink,
+    getSettings,
+    setSettings,
+  };
+}

--- a/ophirofox/content_scripts/europresse_login.js
+++ b/ophirofox/content_scripts/europresse_login.js
@@ -3,10 +3,11 @@ if (!window.location.hash.includes("ophirofox_reloaded")) {
     document.body.innerHTML = "Authentification...";
     const ifr = document.createElement("iframe");
     ifr.width = ifr.height = 5;
-    //ifr.src = "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
-    ifr.src = "https://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
-    ifr.onload = _ => {
+    ifr.onload = (_) => {
         window.location.reload();
-    }
-    document.body.appendChild(ifr);
+    };
+    ophirofox_config.then((conf) => {
+        ifr.src = conf.AUTH_URL;
+        document.body.appendChild(ifr);
+    });
 }

--- a/ophirofox/content_scripts/europresse_login.js
+++ b/ophirofox/content_scripts/europresse_login.js
@@ -4,7 +4,7 @@ if (!window.location.hash.includes("ophirofox_reloaded")) {
     const ifr = document.createElement("iframe");
     ifr.width = ifr.height = 5;
     //ifr.src = "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
-    ifr.src = "http://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
+    ifr.src = "https://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
     ifr.onload = _ => {
         window.location.reload();
     }

--- a/ophirofox/content_scripts/europresse_login.js
+++ b/ophirofox/content_scripts/europresse_login.js
@@ -3,6 +3,7 @@ if (!window.location.hash.includes("ophirofox_reloaded")) {
     document.body.innerHTML = "Authentification...";
     const ifr = document.createElement("iframe");
     ifr.width = ifr.height = 5;
+    //ifr.src = "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
     ifr.src = "http://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
     ifr.onload = _ => {
         window.location.reload();

--- a/ophirofox/content_scripts/europresse_login.js
+++ b/ophirofox/content_scripts/europresse_login.js
@@ -3,7 +3,7 @@ if (!window.location.hash.includes("ophirofox_reloaded")) {
     document.body.innerHTML = "Authentification...";
     const ifr = document.createElement("iframe");
     ifr.width = ifr.height = 5;
-    ifr.src = "https://proxy.rubens.ens.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=PSLT_1";
+    ifr.src = "http://rp1.ensam.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=AML";
     ifr.onload = _ => {
         window.location.reload();
     }

--- a/ophirofox/content_scripts/europresse_view.js
+++ b/ophirofox/content_scripts/europresse_view.js
@@ -2,5 +2,6 @@ if (document.body.textContent.match("Désolé ! Une erreur est survenue")) {
     const ophirofox_target = window.location;
     //const service = `https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
     const service = `https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
-    window.location = "https://sso.ens.fr/cas/login?service=" + encodeURIComponent(service);
+    //window.location = "https://sso.ens.fr/cas/login?service=" + encodeURIComponent(service);
+    window.location = "https://auth.ensam.eu/cas/login?service=" + encodeURIComponent(service);
 }

--- a/ophirofox/content_scripts/europresse_view.js
+++ b/ophirofox/content_scripts/europresse_view.js
@@ -1,5 +1,6 @@
 if (document.body.textContent.match("Désolé ! Une erreur est survenue")) {
     const ophirofox_target = window.location;
-    const service = `https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
+    //const service = `https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
+    const service = `https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
     window.location = "https://sso.ens.fr/cas/login?service=" + encodeURIComponent(service);
 }

--- a/ophirofox/content_scripts/europresse_view.js
+++ b/ophirofox/content_scripts/europresse_view.js
@@ -1,7 +1,0 @@
-if (document.body.textContent.match("Désolé ! Une erreur est survenue")) {
-    const ophirofox_target = window.location;
-    //const service = `https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
-    const service = `https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading?ophirofox_target=${encodeURIComponent(ophirofox_target)}`;
-    //window.location = "https://sso.ens.fr/cas/login?service=" + encodeURIComponent(service);
-    window.location = "https://auth.ensam.eu/cas/login?service=" + encodeURIComponent(service);
-}

--- a/ophirofox/content_scripts/lefigaro.css
+++ b/ophirofox/content_scripts/lefigaro.css
@@ -1,8 +1,3 @@
 .ophirofox-europresse {
-    margin:0 8px;
-    padding:4px 16px;
-    display:block;
-    font-family:source-sans-pro,sans-serif;
-    background-color:#fff7E4;
-    color:#163860;
+    margin-left: 10px;
 }

--- a/ophirofox/content_scripts/lefigaro.js
+++ b/ophirofox/content_scripts/lefigaro.js
@@ -2,7 +2,8 @@ function makeEuropresseUrl(lemondeUrl) {
     const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
     target_url.searchParams.set("ophirofox_source", window.location);
     target_url.searchParams.set("ophirofox_keywords", extractKeywords());
-    const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    const url = new URL("https://auth.ensam.eu/cas/login?url=" + target_url);
     return url;
 }
 

--- a/ophirofox/content_scripts/lefigaro.js
+++ b/ophirofox/content_scripts/lefigaro.js
@@ -3,7 +3,7 @@ function makeEuropresseUrl(lemondeUrl) {
     target_url.searchParams.set("ophirofox_source", window.location);
     target_url.searchParams.set("ophirofox_keywords", extractKeywords());
     //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
-    const url = new URL("https://auth.ensam.eu/cas/login?url=" + target_url);
+    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
     return url;
 }
 

--- a/ophirofox/content_scripts/lefigaro.js
+++ b/ophirofox/content_scripts/lefigaro.js
@@ -11,7 +11,7 @@ async function createLink() {
     const a = document.createElement("a");
     a.href = await makeEuropresseUrl(new URL(window.location));
     a.textContent = "Lire sur Europresse";
-    a.className = "ophirofox-europresse";
+    a.className = "fig-premium-mark-article__text ophirofox-europresse";
     return a;
 }
 
@@ -19,8 +19,8 @@ async function createLink() {
 function findPremiumBanner() {
     const title = document.querySelector("h1");
     if (!title) return null;
-    const divs = title.parentElement.querySelectorAll("div>div");
-    return [...divs].find(d => d.textContent.includes("Réservé aux abonnés"))
+    const elems = title.parentElement.querySelectorAll("span");
+    return [...elems].find(d => d.textContent.includes("Réservé aux abonnés"))
 }
 
 async function onLoad() {

--- a/ophirofox/content_scripts/lefigaro.js
+++ b/ophirofox/content_scripts/lefigaro.js
@@ -1,19 +1,15 @@
-function makeEuropresseUrl(lemondeUrl) {
-    const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
-    target_url.searchParams.set("ophirofox_source", window.location);
-    target_url.searchParams.set("ophirofox_keywords", extractKeywords());
-    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
-    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
-    return url;
+async function makeEuropresseUrl() {
+    const keywords = extractKeywords();
+    return await makeOphirofoxReadingLink(keywords);
 }
 
 function extractKeywords() {
     return document.querySelector("h1").textContent;
 }
 
-function createLink() {
+async function createLink() {
     const a = document.createElement("a");
-    a.href = makeEuropresseUrl(new URL(window.location));
+    a.href = await makeEuropresseUrl(new URL(window.location));
     a.textContent = "Lire sur Europresse";
     a.className = "ophirofox-europresse";
     return a;
@@ -27,10 +23,10 @@ function findPremiumBanner() {
     return [...divs].find(d => d.textContent.includes("Réservé aux abonnés"))
 }
 
-function onLoad() {
+async function onLoad() {
     const premiumBanner = findPremiumBanner();
     if (!premiumBanner) return;
-    premiumBanner.after(createLink());
+    premiumBanner.after(await createLink());
 }
 
-onLoad();
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/lemonde.js
+++ b/ophirofox/content_scripts/lemonde.js
@@ -1,15 +1,9 @@
-function makeEuropresseUrl(lemondeUrl) {
+async function makeEuropresseUrl(lemondeUrl) {
     const m = lemondeUrl.pathname.match(/(\d{4})\/(\d{2})\/(\d{2})\/.*?(\d+_\d+).html/);
     if (!m) throw new Error("Format d'URL lemonde inconnu");
-    const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
-    //target_url.searchParams.set("docKey", `news·${m[1]}${m[2]}${m[3]}·LMF·${m[4]}`);
-    target_url.searchParams.set("ophirofox_source", window.location);
-    target_url.searchParams.set("ophirofox_keywords", extractKeywords());
-    //target_url.hash = "docText";
-    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
-    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
-
-    return url;
+    // docKey : `news·${m[1]}${m[2]}${m[3]}·LMF·${m[4]}`);
+    const keywords = extractKeywords();
+    return await makeOphirofoxReadingLink(keywords);
 }
 
 function extractKeywords() {
@@ -28,18 +22,18 @@ function extractKeywordsFromUrl(url) {
     return lemonde_match[1];
 }
 
-function createLink() {
+async function createLink() {
     const a = document.createElement("a");
-    a.href = makeEuropresseUrl(new URL(window.location));
     a.textContent = "Lire sur Europresse";
     a.className = "btn btn--premium ophirofox-europresse";
+    a.href = await makeEuropresseUrl(new URL(window.location));
     return a;
 }
 
-function onLoad() {
+async function onLoad() {
     const statusElem = document.querySelector(".article__status");
     if (!statusElem) return;
-    statusElem.appendChild(createLink());
+    statusElem.appendChild(await createLink());
 }
 
-onLoad();
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/lemonde.js
+++ b/ophirofox/content_scripts/lemonde.js
@@ -7,7 +7,7 @@ function makeEuropresseUrl(lemondeUrl) {
     target_url.searchParams.set("ophirofox_keywords", extractKeywords());
     //target_url.hash = "docText";
     //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
-    const url = new URL("https://auth.ensam.eu/cas/login?url=" + target_url);
+    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
 
     return url;
 }

--- a/ophirofox/content_scripts/lemonde.js
+++ b/ophirofox/content_scripts/lemonde.js
@@ -6,7 +6,9 @@ function makeEuropresseUrl(lemondeUrl) {
     target_url.searchParams.set("ophirofox_source", window.location);
     target_url.searchParams.set("ophirofox_keywords", extractKeywords());
     //target_url.hash = "docText";
-    const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    const url = new URL("https://auth.ensam.eu/cas/login?url=" + target_url);
+
     return url;
 }
 

--- a/ophirofox/content_scripts/liberation.js
+++ b/ophirofox/content_scripts/liberation.js
@@ -2,7 +2,8 @@ function makeEuropresseUrl(lemondeUrl) {
     const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
     target_url.searchParams.set("ophirofox_source", window.location);
     target_url.searchParams.set("ophirofox_keywords", extractKeywordsFromUrl(window.location));
-    const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
+    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
     return url;
 }
 

--- a/ophirofox/content_scripts/liberation.js
+++ b/ophirofox/content_scripts/liberation.js
@@ -1,10 +1,6 @@
-function makeEuropresseUrl(lemondeUrl) {
-    const target_url = new URL("https://nouveau.europresse.com/Search/Reading");
-    target_url.searchParams.set("ophirofox_source", window.location);
-    target_url.searchParams.set("ophirofox_keywords", extractKeywordsFromUrl(window.location));
-    //const url = new URL("http://proxy.rubens.ens.fr/login?url=" + target_url);
-    const url = new URL("http://rp1.ensam.eu/login?url=" + target_url);
-    return url;
+async function makeEuropresseUrl() {
+    const keywords = extractKeywordsFromUrl(window.location);
+    return await makeOphirofoxReadingLink(keywords);
 }
 
 function extractKeywordsFromUrl(url) {
@@ -14,18 +10,18 @@ function extractKeywordsFromUrl(url) {
     return keywords_in_url[1];
 }
 
-function createLink() {
+async function createLink() {
     const a = document.createElement("a");
-    a.href = makeEuropresseUrl(new URL(window.location));
+    a.href = await makeEuropresseUrl(new URL(window.location));
     a.textContent = "Lire sur Europresse";
     a.className = "ribbon-premium ophirofox-europresse";
     return a;
 }
 
-function onLoad() {
+async function onLoad() {
     const statusElem = document.querySelector(".article-header .ribbon-premium");
     if (!statusElem) return;
-    statusElem.after(createLink());
+    statusElem.after(await createLink());
 }
 
 onLoad();

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -2,10 +2,13 @@
   "manifest_version": 2,
   "name": "Ophirofox",
   "version": "1.6",
-  "description": "Lire les articles du monde grâce à sa connexion europresse",
+  "description": "Lire les articles du monde, du figaro, et d'autres journaux grâce à sa connexion europresse",
   "icons": {
     "48": "icons/48.png",
     "128": "icons/128.png"
+  },
+  "options_ui": {
+    "page": "settings/options_ui.html"
   },
   "permissions": [
     "storage"

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -44,6 +44,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
+        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*"
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*"
       ],
       "js": [
@@ -53,6 +54,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Login*",
+        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Login*"
         "https://nouveau-europresse-com.rp1.ensam.eu/Login*"
       ],
       "js": [
@@ -62,6 +64,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/ResultMobile*",
+        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/ResultMobile*"
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/ResultMobile*"
       ],
       "css": [

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Ophirofox",
-  "version": "1.5",
+  "version": "1.6",
   "description": "Lire les articles du monde grâce à sa connexion europresse",
   "icons": {
     "48": "icons/48.png",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -7,12 +7,16 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
+  "permissions": [
+    "storage"
+  ],
   "content_scripts": [
     {
       "matches": [
         "https://www.lemonde.fr/*"
       ],
       "js": [
+        "content_scripts/config.js",
         "content_scripts/lemonde.js"
       ],
       "css": [
@@ -25,6 +29,7 @@
         "https://next.liberation.fr/*"
       ],
       "js": [
+        "content_scripts/config.js",
         "content_scripts/liberation.js"
       ],
       "css": [
@@ -36,6 +41,7 @@
         "https://www.lefigaro.fr/*"
       ],
       "js": [
+        "content_scripts/config.js",
         "content_scripts/lefigaro.js"
       ],
       "css": [
@@ -59,6 +65,7 @@
         "https://nouveau-europresse-com.rp1.ensam.eu/Login*"
       ],
       "js": [
+        "content_scripts/config.js",
         "content_scripts/europresse_login.js"
       ]
     },

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -21,7 +21,8 @@
     },
     {
       "matches": [
-        "https://www.liberation.fr/*"
+        "https://www.liberation.fr/*",
+        "https://next.liberation.fr/*"
       ],
       "js": [
         "content_scripts/liberation.js"

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -45,7 +45,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
-        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*"
+        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*"
       ],
       "js": [
@@ -55,7 +55,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Login*",
-        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Login*"
+        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Login*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Login*"
       ],
       "js": [
@@ -65,7 +65,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/ResultMobile*",
-        //"https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/ResultMobile*"
+        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/ResultMobile*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/ResultMobile*"
       ],
       "css": [

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -44,7 +44,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
-        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*"
+        "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*"
       ],
       "js": [
         "content_scripts/europresse_search.js"
@@ -53,7 +53,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Login*",
-        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Login*"
+        "https://nouveau-europresse-com.rp1.ensam.eu/Login*"
       ],
       "js": [
         "content_scripts/europresse_login.js"
@@ -62,7 +62,7 @@
     {
       "matches": [
         "https://nouveau.europresse.com/Search/ResultMobile*",
-        "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/ResultMobile*"
+        "https://nouveau-europresse-com.rp1.ensam.eu/Search/ResultMobile*"
       ],
       "css": [
         "content_scripts/europresse_article.css"

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -13,6 +13,9 @@
   "permissions": [
     "storage"
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "content_scripts": [
     {
       "matches": [

--- a/ophirofox/settings/options_ui.html
+++ b/ophirofox/settings/options_ui.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Ophirofox configuration</title>
+    <style>
+      fieldset {
+        margin: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Configuration d'Ophirofox</h1>
+    <form id="configuration">
+      <fieldset>
+        <legend>Partenaire Europresse</legend>
+        <p>
+          Ophirofox supporte plusieurs universités partenaires d'Europresse.
+        </p>
+        <p>Partenaire Europresse à utiliser:</p>
+        <p id="partner_choices"></p>
+      </fieldset>
+    </form>
+
+    <template id="partner_template">
+      <label>
+        <input type="radio" name="partner" />
+        <span id="partner_name">Partner name</span>
+      </label>
+    </template>
+    <script type="module" src="options_ui.js"></script>
+  </body>
+</html>

--- a/ophirofox/settings/options_ui.html
+++ b/ophirofox/settings/options_ui.html
@@ -29,6 +29,7 @@
         <span id="partner_name">Partner name</span>
       </label>
     </template>
+    <script src="../content_scripts/config.js"></script>
     <script type="module" src="options_ui.js"></script>
   </body>
 </html>

--- a/ophirofox/settings/options_ui.js
+++ b/ophirofox/settings/options_ui.js
@@ -1,0 +1,24 @@
+import {
+  ophirofox_config_list,
+  getSettings,
+  setSettings,
+} from "../content_scripts/config.js";
+
+const choicelist = document.getElementById("partner_choices");
+const template = document.getElementById("partner_template");
+const settings_promise = getSettings();
+
+ophirofox_config_list.forEach(({ name }) => {
+  const clone = template.content.cloneNode(true);
+  const span = clone.getElementById("partner_name");
+  /** @type {HTMLInputElement} */
+  const input = clone.querySelector("input");
+  span.textContent = name;
+  choicelist.appendChild(clone);
+  settings_promise.then((settings) => {
+    input.checked = settings.partner_name === name;
+    input.onchange = (evt) => {
+      if (input.checked) setSettings({ ...settings, partner_name: name });
+    };
+  });
+});

--- a/ophirofox/settings/options_ui.js
+++ b/ophirofox/settings/options_ui.js
@@ -1,8 +1,8 @@
-import {
+const {
   ophirofox_config_list,
   getSettings,
   setSettings,
-} from "../content_scripts/config.js";
+} = window.ophirofox_config_exports;
 
 const choicelist = document.getElementById("partner_choices");
 const template = document.getElementById("partner_template");
@@ -17,7 +17,7 @@ ophirofox_config_list.forEach(({ name }) => {
   choicelist.appendChild(clone);
   settings_promise.then((settings) => {
     input.checked = settings.partner_name === name;
-    input.onchange = (evt) => {
+    input.onchange = () => {
       if (input.checked) setSettings({ ...settings, partner_name: name });
     };
   });


### PR DESCRIPTION
le systeme d'authentification ENSAM est tres similaire a celui de l'ENS. j'ai donc modifié les liens :
- vers europresse qui renvoie vers le site d'authentification de l'ENSAM
- vers le site authentification de l'ensam
- vers le sous domaine ENSAM dedié à la bibliotheque
(j'avais initialement retiré les liens ENS pus je les remis en commentaire)