### PR TITLE
Ajout du quotidien La Croix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ L'extension fonctionne avec les portails universitaires suivants :
   - [Le Figaro](https://www.lefigaro.fr/)
   - [Libération](https://www.liberation.fr/)
   - [Le Monde Diplomatique](https://www.www.monde-diplomatique.fr)
+  - [La Croix](https://www.la-croix.com)
 
 Vous pouvez proposer d'autres sites en ouvrant une [demande sur github](https://github.com/lovasoa/ophirofox/issues)
 

--- a/ophirofox/content_scripts/lacroix.css
+++ b/ophirofox/content_scripts/lacroix.css
@@ -1,0 +1,21 @@
+.ophirofox-europresse {
+    -webkit-font-smoothing: antialiased;
+    align-items: center;
+    background-color: #ef7c03;
+    color: #fff;
+    display: inline-flex;
+    font-family: Public Sans,sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    height: 15px;
+    hyphens: none;
+    justify-content: center;
+    letter-spacing: 0;
+    line-height: 1.35;
+    margin: 0 5px;
+    position: relative;
+    text-align: center;
+    top: 50%;
+    vertical-align: middle;
+    width: 120px;
+}

--- a/ophirofox/content_scripts/lacroix.js
+++ b/ophirofox/content_scripts/lacroix.js
@@ -1,0 +1,29 @@
+async function makeEuropresseUrl(lacroixUrl) {
+    const keywords = extractKeywords();
+    return await makeOphirofoxReadingLink(keywords);
+}
+
+function extractKeywords() {
+    return extractKeywordsFromTitle();
+}
+
+function extractKeywordsFromTitle() {
+    const titleElem = document.querySelector(".tag-subscriber");
+    return titleElem && titleElem.textContent;
+}
+
+async function createLink() {
+    const a = document.createElement("a");
+    a.textContent = "Lire sur Europresse";
+    a.className = "ophirofox-europresse";
+    a.href = await makeEuropresseUrl(new URL(window.location));
+    return a;
+}
+
+async function onLoad() {
+    const statusElem = document.querySelector(".tag-subscriber");
+    if (!statusElem) return;
+    statusElem.appendChild(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -67,6 +67,18 @@
     },
     {
       "matches": [
+        "https://www.la-croix.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/lacroix.js"
+      ],
+      "css": [
+        "content_scripts/lacroix.css"
+      ]
+    },
+    {
+      "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
         "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*",


### PR DESCRIPTION
Seule différence avec les autres implémentations, un lien est créé pour l’article en une directement sur la page d’accueil, mais je ne pense pas que ce soit gênant, au contraire.