### PR TITLE
Ajout des sites L'Humanite et LaMontagne

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ L'extension fonctionne avec les portails universitaires suivants :
   - [Le Monde Diplomatique](https://www.www.monde-diplomatique.fr)
   - [La Croix](https://www.la-croix.com)
   - [Courrier international](https://www.courrierinternational.com)
+  - [L'Humanité](https://www.humanite.fr)
+  - [La Montagne](https://www.lamontagne.fr)
+  - [Le Point](https://www.lepoint.fr)
 
 Vous pouvez proposer d'autres sites en ouvrant une [demande sur github](https://github.com/lovasoa/ophirofox/issues)
 

--- a/ophirofox/content_scripts/humanite.js
+++ b/ophirofox/content_scripts/humanite.js
@@ -8,23 +8,26 @@ function extractKeywords() {
 }
 
 async function createLink() {
-	const span = document.createElement("span");
-    span.textContent = "Lire sur Europresse";
-    span.className = "premium-message ophirofox-europresse";
-	
     const a = document.createElement("a");
     a.href = await makeEuropresseUrl(new URL(window.location));
+    a.textContent = "Lire sur Europresse";
 	
-	a.appendChild(span);
+	const div = document.createElement("div");
+    div.className = "field-name-field-news-auteur ophirofox-europresse";
 	
-    return a;
+	div.appendChild(a);
+	
+    return div;
 }
 
 async function onLoad() {
-	const reserve = document.querySelector(".premium-message");
+	const reserve = document.querySelector(".qiota_reserve");
     if (!reserve) return;
 	
-    reserve.parentElement.appendChild(await createLink());
+    const auteurElem = document.querySelector(".group-ft-auteur-date-media");
+    if (!auteurElem) return;
+	
+    auteurElem.appendChild(await createLink());
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/humanite.js
+++ b/ophirofox/content_scripts/humanite.js
@@ -12,16 +12,16 @@ async function createLink() {
     a.href = await makeEuropresseUrl(new URL(window.location));
     a.textContent = "Lire sur Europresse";
 	
-	const div = document.createElement("div");
+    const div = document.createElement("div");
     div.className = "field-name-field-news-auteur ophirofox-europresse";
-	
-	div.appendChild(a);
+
+    div.appendChild(a);
 	
     return div;
 }
 
 async function onLoad() {
-	const reserve = document.querySelector(".qiota_reserve");
+    const reserve = document.querySelector(".qiota_reserve");
     if (!reserve) return;
 	
     const auteurElem = document.querySelector(".group-ft-auteur-date-media");

--- a/ophirofox/content_scripts/la-montagne.css
+++ b/ophirofox/content_scripts/la-montagne.css
@@ -1,0 +1,3 @@
+.ophirofox-europresse {
+    padding: 10px !important;
+}

--- a/ophirofox/content_scripts/la-montagne.js
+++ b/ophirofox/content_scripts/la-montagne.js
@@ -8,22 +8,22 @@ function extractKeywords() {
 }
 
 async function createLink() {
-	const span = document.createElement("span");
+    const span = document.createElement("span");
     span.textContent = "Lire sur Europresse";
     span.className = "premium-message ophirofox-europresse";
-	
+
     const a = document.createElement("a");
     a.href = await makeEuropresseUrl(new URL(window.location));
-	
-	a.appendChild(span);
-	
+
+    a.appendChild(span);
+
     return a;
 }
 
 async function onLoad() {
-	const reserve = document.querySelector(".premium-message");
+    const reserve = document.querySelector(".premium-message");
     if (!reserve) return;
-	
+
     reserve.parentElement.appendChild(await createLink());
 }
 

--- a/ophirofox/content_scripts/la-montagne.js
+++ b/ophirofox/content_scripts/la-montagne.js
@@ -1,0 +1,29 @@
+async function makeEuropresseUrl() {
+    const keywords = extractKeywords();
+    return await makeOphirofoxReadingLink(keywords);
+}
+
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+	const span = document.createElement("span");
+    span.textContent = "Lire sur Europresse";
+    span.className = "premium-message ophirofox-europresse";
+	
+    const a = document.createElement("a");
+    a.href = await makeEuropresseUrl(new URL(window.location));
+	
+	a.appendChild(span);
+	
+    return a;
+}
+async function onLoad() {
+	const reserve = document.querySelector(".premium-message");
+    if (!reserve) return;
+	
+    reserve.parentElement.appendChild(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/le-point.css
+++ b/ophirofox/content_scripts/le-point.css
@@ -1,0 +1,3 @@
+.ophirofox-europresse {
+    margin-left: 10px;
+}

--- a/ophirofox/content_scripts/le-point.js
+++ b/ophirofox/content_scripts/le-point.js
@@ -1,0 +1,30 @@
+async function makeEuropresseUrl() {
+    const keywords = extractKeywords();
+    return await makeOphirofoxReadingLink(keywords);
+}
+
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+    const a = document.createElement("a");
+	a.textContent = "Lire sur Europresse";
+    a.href = await makeEuropresseUrl(new URL(window.location));
+	
+    const span = document.createElement("span");
+    span.className = "ophirofox-europresse";
+	
+    span.appendChild(a);
+
+    return span;
+}
+
+async function onLoad() {
+    const reserve = document.querySelector(".ArticleHeader > .subscribers-only");
+    if (!reserve) return;
+
+    reserve.appendChild(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -89,6 +89,18 @@
         "content_scripts/courrier-international.css"
       ]
     },
+	{
+      "matches": [
+        "https://www.lamontagne.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/la-montagne.js"
+      ],
+      "css": [
+        "content_scripts/la-montagne.css"
+      ]
+    },
     {
       "matches": [
         "https://nouveau.europresse.com/Search/Reading*",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -103,6 +103,15 @@
     },
     {
       "matches": [
+        "https://www.humanite.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/humanite.js"
+      ]
+    },
+    {
+      "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
         "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -112,6 +112,18 @@
     },
     {
       "matches": [
+        "https://www.lepoint.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/le-point.js"
+      ],
+      "css": [
+        "content_scripts/le-point.css"
+      ]
+    },
+    {
+      "matches": [
         "https://nouveau.europresse.com/Search/Reading*",
         "https://nouveau-europresse-com.proxy.rubens.ens.fr/Search/Reading*",
         "https://nouveau-europresse-com.rp1.ensam.eu/Search/Reading*",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -89,7 +89,7 @@
         "content_scripts/courrier-international.css"
       ]
     },
-	{
+    {
       "matches": [
         "https://www.lamontagne.fr/*"
       ],


### PR DESCRIPTION
Bonjour, cette modification permet d'ajouter un bouton "Lire sur Europresse" sur les articles des sites L'Humanité et LaMontagne.