### PR TITLE
Ajoute le support ENS de Lyon

### DIFF
--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -64,6 +64,13 @@ const ophirofox_config_list = [
       "https://docelec.u-bordeaux.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=UNIVBORDEAUXT_1",
   },
   {
+    name: "ENS de Lyon",
+    domains: ["ens-lyon.fr"],
+    LOGIN_URL: "https://acces.bibliotheque-diderot.fr/login",
+    AUTH_URL:
+      "https://acces.bibliotheque-diderot.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=ENSLYONT_1",
+  },
+  {
     name: "Pas d'intermédiaire",
     domains: ["europresse.com"],
     LOGIN_URL: null,

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -134,7 +134,8 @@
         "https://nouveau-europresse-com.sid2nomade-2.grenet.fr/Search/Reading*",
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Search/Reading*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Search/Reading*",
-        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/Reading*"
+        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/Reading*",
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/Reading*"
       ],
       "js": [
         "content_scripts/europresse_search.js"
@@ -151,7 +152,8 @@
         "https://nouveau-europresse-com.sid2nomade-2.grenet.fr/Login*",
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Login*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Login*",
-        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Login*"
+        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Login*",
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Login*"
       ],
       "js": [
         "content_scripts/config.js",
@@ -169,7 +171,8 @@
         "https://nouveau-europresse-com.sid2nomade-2.grenet.fr/Search/ResultMobile*",
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Search/ResultMobile*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Search/ResultMobile*",
-        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/ResultMobile*"
+        "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/ResultMobile*",
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/ResultMobile*"
       ],
       "css": [
         "content_scripts/europresse_article.css"


### PR DESCRIPTION
L'unique commit ajoute l'authentification via le CAS de l'ENS de Lyon (via la BU Diderot). Testé sous Firefox et Chromium.
Résout #23.