### PR TITLE
Ajoute le support de l'Université de Haute-Alsace 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ L'extension fonctionne avec les portails universitaires suivants :
  - [**Europresse Université de Bordeaux**](https://docelec.u-bordeaux.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=UNIVBORDEAUXT_1)
  - [**Europresse Université de Montpellier**](https://ezpum.scdi-montpellier.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=MontpellierT_1)
  - [**Europresse Université de Grenoble**](https://sid2nomade-2.grenet.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=grenobleT_1)
+ - [**Europresse Université de Haute-Alsace**](https://scd-proxy.uha.fr/login?url=http://nouveau.europresse.com/access/ip/default.aspx?un=ALSACET_1)
 
  Ou directement via le site Europresse.
 

--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -71,6 +71,13 @@ const ophirofox_config_list = [
       "https://acces.bibliotheque-diderot.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=ENSLYONT_1",
   },
   {
+    name: "Université de Haute-Alsace",
+    domains: ["uha.fr"],
+    LOGIN_URL: "https://scd-proxy.uha.fr/login",
+    AUTH_URL:
+      "https://scd-proxy.uha.fr/login?url=http://nouveau.europresse.com/access/ip/default.aspx?un=ALSACET_1",
+  },
+  {
     name: "Pas d'intermédiaire",
     domains: ["europresse.com"],
     LOGIN_URL: null,

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -135,7 +135,8 @@
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Search/Reading*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Search/Reading*",
         "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/Reading*",
-        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/Reading*"
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/Reading*",
+        "https://nouveau-europresse-com.scd-proxy.uha.fr/Search/Reading*"
       ],
       "js": [
         "content_scripts/europresse_search.js"
@@ -153,7 +154,8 @@
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Login*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Login*",
         "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Login*",
-        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Login*"
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Login*",
+        "https://nouveau-europresse-com.scd-proxy.uha.fr/Login*"
       ],
       "js": [
         "content_scripts/config.js",
@@ -172,7 +174,8 @@
         "https://nouveau-europresse-com.ezpum.scdi-montpellier.fr/Search/ResultMobile*",
         "https://nouveau-europresse-com.ezproxy.u-bordeaux-montaigne.fr/Search/ResultMobile*",
         "https://nouveau-europresse-com.docelec.u-bordeaux.fr/Search/ResultMobile*",
-        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/ResultMobile*"
+        "https://nouveau-europresse-com.acces.bibliotheque-diderot.fr/Search/ResultMobile*",
+        "https://nouveau-europresse-com.scd-proxy.uha.fr/Search/ResultMobile*"
       ],
       "css": [
         "content_scripts/europresse_article.css"


### PR DESCRIPTION
Les commit ajoute l'authentification via le CAS de l'Université de Haute-Alsace (Mulhouse et Colmar). Testé sous Firefox