### PR TITLE
Update manifest.json Université de Rennes

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -413,7 +413,7 @@
         },
         {
           "name": "Université de Rennes",
-          "AUTH_URL": "https://nouveau-europresse-com.passerelle.univ-rennes1.fr/login?ur1=https://nouveau-europresse-com.passerelle.univ-rennes1.fr/access/ip/default.aspx?un=RENNES1AT_1"
+          "AUTH_URL": "https://passerelle.univ-rennes1.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=RENNES1AT_1"
         },
         {
           "name": "Université de Toulouse",


### PR DESCRIPTION
remplacement de l'URL d'accès à Europresse pour l'Université de Rennes (issue #87)