### PR TITLE
Update manifest.json Université d'Évry Val d'Essonne

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -337,7 +337,7 @@
         },
         {
           "name": "Université d'Évry Val d'Essonne",
-          "AUTH_URL": "https://nouveau-europresse-com.ezproxy.universite-paris-saclay.fr/access/ip/default.aspx?un=U031535T_8"
+          "AUTH_URL": "https://ezproxy.universite-paris-saclay.fr/login?url=http://nouveau.europresse.com/access/ip/default.aspx?un=U031535T_8"
         },
         {
           "name": "Université de Bordeaux",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -336,6 +336,10 @@
           "AUTH_URL": "http://ezproxy.univ-artois.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=littoralT_1"
         },
         {
+          "name": "Université d'Évry Val d'Essonne",
+          "AUTH_URL": "https://nouveau-europresse-com.ezproxy.universite-paris-saclay.fr/access/ip/default.aspx?un=U031535T_8"
+        },
+        {
           "name": "Université de Bordeaux",
           "AUTH_URL": "https://docelec.u-bordeaux.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=UNIVBORDEAUXT_1"
         },


### PR DESCRIPTION
Le proxy est mutualisé avec Université Paris Saclay. Il n'a pas été rajouté dans la section des URL. Mais comme chaque établissement a son propre jeton l'Université d'Évry a été rajoutée dans la section Name...