### PR TITLE
Lycée International de l'Est Parisien

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -347,6 +347,10 @@
           "name": "Le Mans Université",
           "AUTH_URL": "https://login.doc-elec.univ-lemans.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=U031524T_1"
         },
+         {
+          "name": "Lycée International de l'Est Parisien",
+          "AUTH_URL": "https://nouveau.europresse.com/Login/Esidoc?sso_id=0932638M"
+        },
         {
           "name": "Médiathèque de Télécom SudParis & Institut Mines-Télécom Business School",
           "AUTH_URL": "http://mediaproxy.imtbs-tsp.eu/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=U033137T_8"

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -347,7 +347,7 @@
           "name": "Le Mans Université",
           "AUTH_URL": "https://login.doc-elec.univ-lemans.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=U031524T_1"
         },
-         {
+        {
           "name": "Lycée International de l'Est Parisien",
           "AUTH_URL": "https://nouveau.europresse.com/Login/Esidoc?sso_id=0932638M"
         },


### PR DESCRIPTION
Rebonjour.
Voici nos URL pour accèder à Europresse.
https://nouveau.europresse.com/Login/Esidoc?sso_id=0932638M

https://idp-auth.gar.education.fr/domaineGar?idENT=SjA=&idEtab=MDkzMjYzOE0=&idRessource=ark%3A%2F57800%2Feuropresse-cision

Je n'ai rien ajouté dans la section qui contient toutes les URLs au format https://nouveau-europresse-com.proxy.univ-xyz.fr/* ne sachant pas quoi renseigner...
Merci