### PR TITLE
Mise à jour de l'url de Télécom Paris

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -469,7 +469,7 @@
         },
         {
           "name": "Télécom Paris",
-          "AUTH_URL": "https://nouveau.europresse.com/access/ip/default.aspx?un=U033137T_1"
+          "AUTH_URL": "https://nouveau.europresse.com/access/httpref/default.aspx?un=U033137T_5"
         },
         {
           "name": "Université Catholique de Lille",


### PR DESCRIPTION
L'ancienne URL ne permet de se connecter sur Europresse que dans la bibliothèque de Télécom Paris. La nouvelle permet de se connecter à distance.