### PR TITLE
Ajout de La DH, l'Avenir et Sudinfo (quotidiens belges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ Si votre université n'est pas dans la liste, vous pouvez [l'ajouter](#comment-a
   
 ### Presse étrangère
   - [Courrier international](https://www.courrierinternational.com)
+  - [L'Avenir (Belgique)](https://www.lavenir.net/)
   - [L'Orient-Le Jour (Liban)](https://www.lorientlejour.com/)
+  - [La DH (Belgique)](https://www.dhnet.be/)
   - [La Libre Belgique](https://www.lalibre.be/)
   - [Le Soir (Belgique)](https://www.lesoir.be)
   - [Le Temps (Suisse)](https://www.letemps.ch/)
+  - [Sudinfo (Belgique)](https://www.sudinfo.be/)
 
 Vous pouvez proposer d'autres sites en ouvrant une [demande sur github](https://github.com/lovasoa/ophirofox/issues)
 

--- a/ophirofox/content_scripts/ladh.css
+++ b/ophirofox/content_scripts/ladh.css
@@ -1,0 +1,11 @@
+.ophirofox-europresse {
+    display: inline-block;
+    margin: 0 0.7em 0 0.1em;
+    padding: 0 1em;
+    border-radius: 0.25rem;
+    background-color: #f7b500;
+    color: #000 !important;
+    font-size: small;
+    vertical-align: middle;
+    line-height: 2.7;
+}

--- a/ophirofox/content_scripts/ladh.js
+++ b/ophirofox/content_scripts/ladh.js
@@ -1,0 +1,18 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+async function onLoad() {
+    const statusElem = document.getElementsByClassName("ap-PaidPicto");
+    if (statusElem.length == 0) return;
+    statusElem[0].after(await createLink());
+}
+
+onLoad().catch(console.error);
+
+//OK

--- a/ophirofox/content_scripts/lavenir.css
+++ b/ophirofox/content_scripts/lavenir.css
@@ -1,0 +1,11 @@
+.ophirofox-europresse {
+    display: inline-block;
+    margin: 0.4em 0.7em 0 -0.25em;
+    padding: 0 1em;
+    border-radius: 0.25em;
+    background-color: #ffcb00;
+    color: #000 !important;
+    font-size: small;
+    vertical-align: top;
+    line-height: 2.5;
+}

--- a/ophirofox/content_scripts/lavenir.js
+++ b/ophirofox/content_scripts/lavenir.js
@@ -1,0 +1,16 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+async function onLoad() {
+    const statusElem = document.getElementsByClassName("ap-PaidPicto");
+    if (statusElem.length == 0) return;
+    statusElem[0].after(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/sudinfo.css
+++ b/ophirofox/content_scripts/sudinfo.css
@@ -1,0 +1,8 @@
+.ophirofox-europresse {
+    display: inline-block;
+    padding: 3px 5px 1px 5px;
+    background-color: #ffc549;
+    color: #000;
+    vertical-align: bottom;
+    font-weight: bold;
+}

--- a/ophirofox/content_scripts/sudinfo.js
+++ b/ophirofox/content_scripts/sudinfo.js
@@ -1,0 +1,23 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+function findPremiumBanner() {
+    const title = document.querySelector("h1");
+    if (!title) return null;
+    const elems = title.parentElement.querySelectorAll("span");
+    return [...elems].find(d => d.classList.contains("r-article--payant"));
+}
+
+async function onLoad() {
+    const premiumBanner = findPremiumBanner();
+    if (!premiumBanner) return;
+    premiumBanner.after(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -414,6 +414,42 @@
       "css": [
         "content_scripts/lorient-lejour.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.lavenir.net/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/lavenir.js"
+      ],
+      "css": [
+        "content_scripts/lavenir.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.dhnet.be/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/ladh.js"
+      ],
+      "css": [
+        "content_scripts/ladh.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.sudinfo.be/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/sudinfo.js"
+      ],
+      "css": [
+        "content_scripts/sudinfo.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Bonjour,

Voici une proposition d'ajout pour 3 quotidiens belges : la DH, l'Avenir et SudInfo.
J'ai ajouté les fichiers js & css et mis à jour le readme et le manifest.json, j'espère que c'est suffisant.
(J'ai testé sur Chrome, à priori ça fonctionne)

Bonne journée!