### PR TITLE
Corrige l'affichage du bouton sur leparisien.fr (Firefox).

### DIFF
--- a/ophirofox/content_scripts/le-parisien.css
+++ b/ophirofox/content_scripts/le-parisien.css
@@ -9,5 +9,7 @@
     text-decoration: none;
     border-radius: 1.25rem;
     padding: 0.7em;
-    vertical-align: middle;
+    margin-bottom: 10px;
+    display: block;
+    width: 135px;
 }

--- a/ophirofox/content_scripts/le-parisien.js
+++ b/ophirofox/content_scripts/le-parisien.js
@@ -8,19 +8,46 @@ async function createLink() {
     return a;
 }
 
+async function addEuropresseButton() {
+    const head = document.querySelector("h1");
+    head.after(await createLink());
+}
 
 function findPremiumBanner() {
-    const title = document.querySelector(".paywall-sticky.width_full.d_flex.pt_3_m.pb_3_m.pt_4_nm.pb_4_nm.pos_stick.ff_gct.fw_r.justify_center");
-    if (!title) return null;
-    const elems = title.parentElement.querySelectorAll("div");
-    return [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"))
+
+    const isFirefox = chrome.runtime.getURL('').startsWith('moz-extension://');
+ 
+    if (isFirefox) {
+        const bannerSelectorString = 'paywall-sticky width_full d_flex pt_3_m pb_3_m pt_4_nm pb_4_nm pos_stick ff_gct fw_r justify_center';
+        const callback = (mutationList, observer) => {
+            for (const mutation of mutationList) {
+                for (const e of mutation.addedNodes) {
+                    if(e.className == bannerSelectorString) {
+                        observer.disconnect();
+                        const elems = e.parentElement.querySelectorAll("div");
+                        const matches = [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
+                        if (matches)
+                            addEuropresseButton();
+                    }
+                }
+            }
+        };
+        const observer = new MutationObserver(callback);
+        observer.observe(document.body, { childList: true });
+    } 
+    else {
+        const bannerSelector = document.querySelector(".paywall-sticky.width_full.d_flex.pt_3_m.pb_3_m.pt_4_nm.pb_4_nm.pos_stick.ff_gct.fw_r.justify_center");
+        if (!bannerSelector) return null;
+        const elems = bannerSelector.parentElement.querySelectorAll("div");
+        const matches = [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
+        if (matches)
+            addEuropresseButton();
+    }
+
 }
 
 async function onLoad() {
-	const premiumBanner = findPremiumBanner();
-    if (!premiumBanner) return;
-    const head = document.querySelector("h1");
-    head.after(await createLink());
+    findPremiumBanner();
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/le-parisien.js
+++ b/ophirofox/content_scripts/le-parisien.js
@@ -16,19 +16,25 @@ async function addEuropresseButton() {
 function findPremiumBanner() {
 
     const isFirefox = chrome.runtime.getURL('').startsWith('moz-extension://');
- 
+
     if (isFirefox) {
         const bannerSelectorString = 'paywall-sticky width_full d_flex pt_3_m pb_3_m pt_4_nm pb_4_nm pos_stick ff_gct fw_r justify_center';
+        var elementFound = false;
         const callback = (mutationList, observer) => {
             for (const mutation of mutationList) {
                 for (const e of mutation.addedNodes) {
                     if(e.className == bannerSelectorString) {
                         observer.disconnect();
+                        elementFound = true;
                         const elems = e.parentElement.querySelectorAll("div");
                         const matches = [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
                         if (matches)
                             addEuropresseButton();
+                        break;
                     }
+                }
+                if (elementFound) {
+                    break;
                 }
             }
         };

--- a/ophirofox/content_scripts/le-parisien.js
+++ b/ophirofox/content_scripts/le-parisien.js
@@ -13,47 +13,38 @@ async function addEuropresseButton() {
     head.after(await createLink());
 }
 
-function findPremiumBanner() {
+function findPremiumBanner(bannerSelector) {
+    if (!bannerSelector) return null;
+    const elems = bannerSelector.parentElement.querySelectorAll("div");
+    return [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
+}
 
-    const isFirefox = chrome.runtime.getURL('').startsWith('moz-extension://');
-
-    if (isFirefox) {
-        const bannerSelectorString = 'paywall-sticky width_full d_flex pt_3_m pb_3_m pt_4_nm pb_4_nm pos_stick ff_gct fw_r justify_center';
-        var elementFound = false;
+async function onLoad() {
+    const bannerSelector = document.querySelector(".paywall-sticky.width_full.d_flex.pt_3_m.pb_3_m.pt_4_nm.pb_4_nm.pos_stick.ff_gct.fw_r.justify_center");
+    if (findPremiumBanner(bannerSelector)) {
+        addEuropresseButton();
+    } 
+    else {
+        /* Premium banner couldn't be found, use MutationObserver as fallback */
         const callback = (mutationList, observer) => {
             for (const mutation of mutationList) {
                 for (const e of mutation.addedNodes) {
+                    const bannerSelectorString = 'paywall-sticky width_full d_flex pt_3_m pb_3_m pt_4_nm pb_4_nm pos_stick ff_gct fw_r justify_center';
+                    var elementFound = false;
                     if(e.className == bannerSelectorString) {
                         observer.disconnect();
                         elementFound = true;
-                        const elems = e.parentElement.querySelectorAll("div");
-                        const matches = [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
-                        if (matches)
+                        if(findPremiumBanner(e)) {
                             addEuropresseButton();
+                        }
                         break;
-                    }
-                }
-                if (elementFound) {
-                    break;
+                    }                    
                 }
             }
         };
         const observer = new MutationObserver(callback);
-        observer.observe(document.body, { childList: true });
-    } 
-    else {
-        const bannerSelector = document.querySelector(".paywall-sticky.width_full.d_flex.pt_3_m.pb_3_m.pt_4_nm.pb_4_nm.pos_stick.ff_gct.fw_r.justify_center");
-        if (!bannerSelector) return null;
-        const elems = bannerSelector.parentElement.querySelectorAll("div");
-        const matches = [...elems].find(d => d.textContent.includes("Cet article est réservé aux abonnés"));
-        if (matches)
-            addEuropresseButton();
+        observer.observe(document.body, { childList: true});
     }
-
-}
-
-async function onLoad() {
-    findPremiumBanner();
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/le-parisien.js
+++ b/ophirofox/content_scripts/le-parisien.js
@@ -26,11 +26,11 @@ async function onLoad() {
     } 
     else {
         /* Premium banner couldn't be found, use MutationObserver as fallback */
+        var elementFound = false;
         const callback = (mutationList, observer) => {
             for (const mutation of mutationList) {
                 for (const e of mutation.addedNodes) {
                     const bannerSelectorString = 'paywall-sticky width_full d_flex pt_3_m pb_3_m pt_4_nm pb_4_nm pos_stick ff_gct fw_r justify_center';
-                    var elementFound = false;
                     if(e.className == bannerSelectorString) {
                         observer.disconnect();
                         elementFound = true;
@@ -39,6 +39,9 @@ async function onLoad() {
                         }
                         break;
                     }                    
+                }
+                if (elementFound) {
+                    break;
                 }
             }
         };


### PR DESCRIPTION
Première tentative de push ici,

Ceci corrige le bouton ne s'affichant pas (où que très rarement) sur leparisien.fr sur le navigateur Firefox.

J'ai bien essayé d'unifier le code pour utiliser le MutationObserver sur Chrome, mais cela ne semble pas arriver à capturer l'element assez rapidement (?), je suis ouvert à propositions là dessus.

Pour le moment je vérifie donc si le navigateur est firefox, et si oui j'utilise l'API MutationObserver, autrement je fais comme avant, car cela a toujours bien fonctionné sur les navigateurs Chromiums. 


Ceci corrige aussi le code CSS du bouton pour qu'il n'empiète plus sur l'entête de l'article.

En attendant vos retours,

Joffrey 