### PR TITLE
Ajout du support pour Le Progrès

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Essayer l'extension dans Firefox
+
+Pour essayer l'extension en cours de développement, suivre ce guide :
+
+https://developer.mozilla.org/fr/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#essai
+
+# Ajout du support d'un site de presse
+
+- Dans le fichier `ophirofox/manifest.json`, ajouter une nouvelle entrée dans le tableau `content_scripts`.
+
+```json
+    {
+      "matches": [
+        "https://www.mon-nouveau-site-de-presse.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/mon-nouveau-site-de-presse.js"
+      ],
+      "css": [
+        "content_scripts/mon-nouveau-site-de-presse.css"
+      ]
+    },
+```
+- Créer les fichiers js et css correspondant, dans le répertoire `ophirofox/content_scripts`
+
+Vous pouvez par exemple copier-coller `ophirofox/content_scripts/lemonde.js` pour servir de base.
+
+- Trouver les mots clés du titre
+
+Dans la méthode `extractKeywordsFromTitle`, modifier le querySelector pour correspondre au titre de l'article
+
+- Trouver les mots clés dans l'url
+
+Tester la regex de la méthode `extractKeywordsFromUrl` pour récupérer les mots clés de l'URL, la modifier si besoin
+
+- Ajouter le bouton Lire sur Europress dans l'entête de l'article
+
+Dans la méthode `onLoad`, modifier le premier querySelector pour trouver la zone où ajouter le bouton, par exemple une div d'informations sous le titre
+
+- Ajouter un second bouton dans le paywall (fenêtre d'abonnement)
+
+S'il y a une fenêtre paywall qui s'affiche, essayer de récupérer le bouton d'abonnement avec un querySelector et ajouter un second lien Europress avant
+
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Voici la liste triée par ordre alphabétique :
   - [Ouest France](https://www.ouest-france.fr/)
   - [Sud Ouest](https://www.sudouest.fr/)
   - [Le Télégramme](https://www.letelegramme.fr/)
+  - [Le Progrès](https://www.leprogres.fr/)
   
 ### Presse étrangère
   - [Courrier international](https://www.courrierinternational.com)

--- a/ophirofox/content_scripts/le-progres.css
+++ b/ophirofox/content_scripts/le-progres.css
@@ -1,0 +1,5 @@
+.ophirofox-europresse {
+    margin-left: 4px;
+    margin-top: 0px;
+
+}

--- a/ophirofox/content_scripts/le-progres.js
+++ b/ophirofox/content_scripts/le-progres.js
@@ -1,16 +1,17 @@
 function extractKeywords() {
-    return extractKeywordsFromTitle() || extractKeywordsFromUrl(window.location);
+    // Works better with keywords from url
+    return extractKeywordsFromUrl(window.location) || extractKeywordsFromTitle();
 }
 
 function extractKeywordsFromTitle() {
-    const titleElem = document.querySelector("article h1");
+    const titleElem = document.querySelector("head > title, article h1");
     return titleElem && titleElem.textContent;
 }
 
 function extractKeywordsFromUrl(url) {
     const source_url = new URL(url);
     const le_progres_match = source_url.pathname.match(/([^/.]+)(_\d*_\d*\.html)?$/);
-    if (!le_progres_match) throw new Error("Could not find keywords in le-progres url");
+    if (!le_progres_match) return false;
     return le_progres_match[1];
 }
 

--- a/ophirofox/content_scripts/le-progres.js
+++ b/ophirofox/content_scripts/le-progres.js
@@ -3,7 +3,7 @@ function extractKeywords() {
 }
 
 function extractKeywordsFromTitle() {
-    const titleElem = document.querySelector("h1");
+    const titleElem = document.querySelector("article h1");
     return titleElem && titleElem.textContent;
 }
 

--- a/ophirofox/content_scripts/le-progres.js
+++ b/ophirofox/content_scripts/le-progres.js
@@ -1,0 +1,58 @@
+function extractKeywords() {
+    return extractKeywordsFromTitle() || extractKeywordsFromUrl(window.location);
+}
+
+function extractKeywordsFromTitle() {
+    const titleElem = document.querySelector("h1");
+    return titleElem && titleElem.textContent;
+}
+
+function extractKeywordsFromUrl(url) {
+    const source_url = new URL(url);
+    const le_progres_match = source_url.pathname.match(/([^/.]+)(_\d*_\d*\.html)?$/);
+    if (!le_progres_match) throw new Error("Could not find keywords in le-progres url");
+    return le_progres_match[1];
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.classList.add("btn", "bt_default");
+    return a;
+}
+
+function waitForElm(selector) {
+    return new Promise(resolve => {
+        if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(mutations => {
+            if (document.querySelector(selector)) {
+                observer.disconnect();
+                resolve(document.querySelector(selector));
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+}
+
+async function onLoad() {
+    const actionElement = document.querySelector(".fullDetailActions");
+    if (actionElement) {
+        actionElement.appendChild(await createLink());
+    }
+
+    let paywallElem = await waitForElm(".p3-advanced-paywall");
+    if (!paywallElem) return;
+
+    const link = await createLink();
+    link.className = "button";
+    paywallElem.parentNode.insertBefore(link, paywallElem);
+    
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -488,6 +488,18 @@
       "css": [
         "content_scripts/lsa-conso.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.leprogres.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/le-progres.js"
+      ],
+      "css": [
+        "content_scripts/le-progres.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Ajout du support pour le journal régional Le Progrès

Ajout d'un fichier CONTRIBUTING pour quelques conseils


La recherche par titre est un peu capricieuse, les titres dans Europresse sont différents, avec moins de mots que ceux du site web, cela fonctionne mieux par URL car ce sont les mots clés du titre original


Un exemple qui fonctionne bien : https://www.leprogres.fr/culture-loisirs/2024/02/08/la-musique-departementale-des-pompiers-en-concert