### PR TITLE
La date de publication peut être transmise en option

### DIFF
--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -72,12 +72,12 @@ const ophirofox_config = getOphirofoxConfig();
  * @param {string} keywords
  * @returns {Promise<HTMLAnchorElement>}
  */
-async function ophirofoxEuropresseLink(keywords) {
+async function ophirofoxEuropresseLink(keywords, { publishedTime } = {}) {
   // Keywords is the article name
   keywords = keywords ? keywords.trim() : document.querySelector("h1").textContent;
 
   // Trying to determine published time with meta tags (Open Graph values)
-  let publishedTime = document.querySelector( "meta[property='article:published_time'], meta[property='og:article:published_time'], meta[property='date:published_time']")
+  publishedTime = publishedTime || document.querySelector( "meta[property='article:published_time'], meta[property='og:article:published_time'], meta[property='date:published_time']")
   ?.getAttribute("content") || '';
 
   // Creating HTML anchor element

--- a/ophirofox/content_scripts/le-progres.js
+++ b/ophirofox/content_scripts/le-progres.js
@@ -15,8 +15,20 @@ function extractKeywordsFromUrl(url) {
     return le_progres_match[1];
 }
 
+function extractPublishDate() {
+    try {
+        const script = document.querySelector("script[type='application/ld+json']")
+        const json = JSON.parse(script.innerText)
+        const datePublished = json[0].datePublished;
+        return datePublished;
+    } catch {
+        // tant pis
+        return null;
+    }
+}
+
 async function createLink() {
-    const a = await ophirofoxEuropresseLink(extractKeywords());
+    const a = await ophirofoxEuropresseLink(extractKeywords(), { publishedTime: extractPublishDate() });
     a.classList.add("btn", "bt_default");
     return a;
 }
@@ -53,7 +65,6 @@ async function onLoad() {
     const link = await createLink();
     link.className = "button";
     paywallElem.parentNode.insertBefore(link, paywallElem);
-    
 }
 
 onLoad().catch(console.error);


### PR DESCRIPTION
Permettre de rechercher la date de publication de manière personnalisée pour un site de presse, et ainsi la transmettre en paramètre pour la création du lien

Exemple avec Le Progrès ;
https://www.leprogres.fr/sport/2024/02/14/deux-familles-amoureuses-de-la-balle-orange