### PR TITLE
Ajout Washington Post, Financial Times et presse belge néerlandophone

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Voici la liste triée par ordre alphabétique :
   - [Courrier international](https://www.courrierinternational.com)
   - [De Morgen (Belgique - néerlandophone)](https://www.demorgen.be/)
   - [De Standaard (Belgique - néerlandophone)](https://www.standaard.be/)
+  - [Financial Times (Royaume-Uni)](https://www.ft.com/)
+  - [Gazet van Antwerpen (Belgique - néerlandophone)](https://www.gva.be/)
+  - [Het Laatste Nieuws (Belgique - néerlandophone)](https://www.hln.be/)
+  - [Het Nieuwsblad (Belgique - néerlandophone)](https://www.nieuwsblad.be/)
   - [Knack (Belgique - néerlandophone)](https://www.knack.be/)
   - [L'Avenir (Belgique)](https://www.lavenir.net/)
   - [L'Orient-Le Jour (Liban)](https://www.lorientlejour.com/)
@@ -64,6 +68,7 @@ Voici la liste triée par ordre alphabétique :
   - [Le Vif (Belgique)](https://www.levif.be/)
   - [Sudinfo (Belgique)](https://www.sudinfo.be/)
   - [The Economist (Royaume-Uni)](https://www.economist.com/)
+  - [The Washington Post (USA)](https://www.washingtonpost.com/)
   - [Trends-Tendances (Belgique)](https://trends.levif.be/)
 
 Vous pouvez proposer d'autres sites Web de médias en ouvrant une [demande ici-même](https://github.com/lovasoa/ophirofox/issues).

--- a/ophirofox/content_scripts/financialtimes.css
+++ b/ophirofox/content_scripts/financialtimes.css
@@ -1,0 +1,8 @@
+.ophirofox-europresse {
+    display: inline-block;
+    margin-bottom: 1rem;
+    padding: 0.25rem 1rem;
+    border: 1px solid #fff;
+    color: #fff;
+    text-decoration: none;
+}

--- a/ophirofox/content_scripts/financialtimes.js
+++ b/ophirofox/content_scripts/financialtimes.js
@@ -1,0 +1,17 @@
+function extractKeywords() {
+    return document.querySelector("#barrier-page h1").textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+async function onLoad() {
+    const paywall = document.querySelector('#barrier-page');
+    if (paywall == null) return;
+    const title = document.querySelector("#barrier-page h1");
+    title.after(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/gazetvanantwerpen.css
+++ b/ophirofox/content_scripts/gazetvanantwerpen.css
@@ -1,0 +1,6 @@
+.ophirofox-europresse {
+    display: block;
+    padding: 0.5rem;
+    border: 1px solid #d21d10;
+    text-align: center;
+}

--- a/ophirofox/content_scripts/gazetvanantwerpen.js
+++ b/ophirofox/content_scripts/gazetvanantwerpen.js
@@ -1,0 +1,34 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+let buttonAdded = false;
+
+async function createLink() {
+    const subscriptionElem = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
+    if (subscriptionElem && buttonAdded == false){
+        const a = await ophirofoxEuropresseLink(extractKeywords());
+        subscriptionElem.after(a);
+    }
+}
+
+async function onLoad() {
+    // Lien Europresse dans la modale au chargement de l'article
+    createLink();
+
+    // Lien Europresse dans le corps de l'article, une fois la modale fermée
+    const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+            if(mutation.removedNodes.length > 0){
+                createLink();
+                buttonAdded = true;
+            }
+        }
+    };
+
+    const htmlElement = document.querySelector('.cj-root');
+    const observer = new MutationObserver(callback);
+    observer.observe(htmlElement, { childList: true});
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/hetlaatstenieuws.css
+++ b/ophirofox/content_scripts/hetlaatstenieuws.css
@@ -1,0 +1,5 @@
+.ophirofox-europresse {
+    display: block;
+    margin-top: 1rem;
+    text-align: center;
+}

--- a/ophirofox/content_scripts/hetlaatstenieuws.js
+++ b/ophirofox/content_scripts/hetlaatstenieuws.js
@@ -1,0 +1,39 @@
+function extractKeywords() {
+    const titleElem = document.querySelector("h1").childNodes[0];
+    return titleElem && titleElem.textContent;
+}
+
+let buttonAdded = false;
+
+async function addEuropresseButton() {
+    if(!buttonAdded) {
+        const elts = document.querySelectorAll('.tm-account');
+        if (elts) {
+            for(let elt of elts){
+                const a = await ophirofoxEuropresseLink(extractKeywords());
+                elt.after(a);
+                buttonAdded = true;
+            }
+        }
+    }
+}
+
+async function onLoad() {
+    const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+            if(mutation.type === 'attributes' && mutation.attributeName === 'class'){
+                const newClassState = mutation.target.classList.contains('js-tm-backdrop-active');
+                if(classState !== newClassState){
+                    addEuropresseButton();
+                }
+            }
+        }
+    };
+
+    const htmlElement = document.querySelector('body');
+    const classState = htmlElement.classList.contains('js-tm-backdrop-active');
+    const observer = new MutationObserver(callback);
+    observer.observe(htmlElement, { attributes: true, subtree: true });
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/hetnieuwsblad.css
+++ b/ophirofox/content_scripts/hetnieuwsblad.css
@@ -1,0 +1,6 @@
+.ophirofox-europresse {
+    display: block;
+    padding: 0.5rem;
+    border: 1px solid #0071c7;
+    text-align: center;
+}

--- a/ophirofox/content_scripts/hetnieuwsblad.js
+++ b/ophirofox/content_scripts/hetnieuwsblad.js
@@ -1,0 +1,34 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+let buttonAdded = false;
+
+async function createLink() {
+    const subscriptionElem = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
+    if (subscriptionElem && buttonAdded == false){
+        const a = await ophirofoxEuropresseLink(extractKeywords());
+        subscriptionElem.after(a);
+    }
+}
+
+async function onLoad() {
+    // Lien Europresse dans la modale au chargement de l'article
+    createLink();
+
+    // Lien Europresse dans le corps de l'article, une fois la modale fermée
+    const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+            if(mutation.removedNodes.length > 0){
+                createLink();
+                buttonAdded = true;
+            }
+        }
+    };
+
+    const htmlElement = document.querySelector('.cj-root');
+    const observer = new MutationObserver(callback);
+    observer.observe(htmlElement, { childList: true});
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/washingtonpost.css
+++ b/ophirofox/content_scripts/washingtonpost.css
@@ -1,0 +1,8 @@
+.ophirofox-europresse {
+    display: flex;
+    justify-content: center;
+    margin: 1rem auto;
+    padding: 0.25rem 1rem;
+    width: 40%;
+    border: 1px solid #1955a5;
+}

--- a/ophirofox/content_scripts/washingtonpost.js
+++ b/ophirofox/content_scripts/washingtonpost.js
@@ -1,0 +1,35 @@
+function extractKeywords() {
+    const titleElem = document.querySelector("h1#main-content");
+    return titleElem.textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+async function onLoad() {
+    let linkAdded = false;
+    const callback = (mutationsList, observer) => {
+        for (const mutation of mutationsList) {
+            if(!linkAdded){
+                const paywall_modal = document.querySelector('[data-qa="overlay-container"]');
+                const paywall_bottom = document.querySelector('#wall-bottom-drawer');
+                if(paywall_modal !== null || paywall_bottom !== null){
+                    const title_bottom = document.querySelector('h1#HEADER');
+                    createLink().then(function(data){
+                        title_bottom.after(data);
+                    });
+                    linkAdded = true;
+                    observer.disconnect();
+                }
+            }
+        }
+    };
+
+    const htmlElement = document.querySelector('body');
+    const observer = new MutationObserver(callback);
+    observer.observe(htmlElement, { attributes: true, subtree: true });
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -573,6 +573,66 @@
       "css": [
         "content_scripts/theeconomist.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.ft.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/financialtimes.js"
+      ],
+      "css": [
+        "content_scripts/financialtimes.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.washingtonpost.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/washingtonpost.js"
+      ],
+      "css": [
+        "content_scripts/washingtonpost.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.gva.be/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/gazetvanantwerpen.js"
+      ],
+      "css": [
+        "content_scripts/gazetvanantwerpen.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.nieuwsblad.be/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/hetnieuwsblad.js"
+      ],
+      "css": [
+        "content_scripts/hetnieuwsblad.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.hln.be/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/hetlaatstenieuws.js"
+      ],
+      "css": [
+        "content_scripts/hetlaatstenieuws.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Bonjour,

Nouvelle proposition d'ajout pour le Financial Times, le Washington Post ainsi que 3 autres journaux belges néerlandophones : Het Laatste Nieuws, Het Nieuwsblad et la Gazet van Antwerpen.

Bonne journée!