### PR TITLE
Fix bugs et style dans presse belge, UK et USA

### DIFF
--- a/ophirofox/content_scripts/demorgen.css
+++ b/ophirofox/content_scripts/demorgen.css
@@ -1,5 +1,11 @@
 .ophirofox-europresse {
     display: block;
-    margin-top: 1rem;
+    width: 12vw;
+    margin: 1rem auto;
+    padding: 0.25rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
     text-align: center;
+    text-decoration: none;
 }

--- a/ophirofox/content_scripts/demorgen.js
+++ b/ophirofox/content_scripts/demorgen.js
@@ -25,6 +25,7 @@ async function onLoad() {
                 const newClassState = mutation.target.classList.contains('js-tm-backdrop-active');
                 if(classState !== newClassState){
                     addEuropresseButton();
+                    observer.disconnect();
                 }
             }
         }

--- a/ophirofox/content_scripts/destandaard.css
+++ b/ophirofox/content_scripts/destandaard.css
@@ -1,8 +1,17 @@
 .ophirofox-europresse {
-    display: block;
-    padding: 0.5rem;
-    background-color: #d90000 !important;
-    color: #fff !important;
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700 !important;
+    color: #000 !important;
     text-align: center;
     text-decoration: none !important;
+}
+
+.ophirofox-modal-link {
+    display: block;
+    margin-top: 0;
+    padding: 0.5rem;
+    border-radius: 0;
 }

--- a/ophirofox/content_scripts/destandaard.js
+++ b/ophirofox/content_scripts/destandaard.js
@@ -1,34 +1,46 @@
 function extractKeywords() {
-    return document.querySelector("h1").textContent;
+    return document.querySelector("header h1").textContent;
 }
 
 let buttonAdded = false;
 
-async function createLink() {
-    const subscriptionElem = document.querySelector('[data-current-screen="CtaAuthPaying"] form');
-    if (subscriptionElem && buttonAdded == false){
+async function createLink(elt) {
+    if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
-        subscriptionElem.after(a);
+        elt.after(a);
     }
 }
 
 async function onLoad() {
-    // Lien Europresse dans la modale au chargement de l'article
-    createLink();
+    // Lien Europresse dans le corps de l'article
+    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
+    const article_title = document.querySelector('header h1');
+    
+    if(paywall){
+        createLink(article_title);
+    }
 
-    // Lien Europresse dans le corps de l'article, une fois la modale fermée
+    // Lien Europresse dans la modale, au chargement
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
-            if(mutation.removedNodes.length > 0){
-                createLink();
-                buttonAdded = true;
+            if(mutation.type === 'childList'){
+                for(let node of mutation.addedNodes){
+                    const paywall_modal = document.querySelector('.cj-root');
+                    if(paywall_modal){
+                        const subscriptionForm = document.querySelector('[data-current-screen="CtaAuthPaying"] form');
+                        createLink(subscriptionForm);
+                        buttonAdded = true;
+                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
+                        observer.disconnect();
+                    }
+                }
             }
         }
     };
 
-    const htmlElement = document.querySelector('.cj-root');
+    const htmlElement = document.querySelector('body');
     const observer = new MutationObserver(callback);
-    observer.observe(htmlElement, { childList: true});
+    observer.observe(htmlElement, { childList: true });
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/financialtimes.css
+++ b/ophirofox/content_scripts/financialtimes.css
@@ -1,8 +1,9 @@
 .ophirofox-europresse {
     display: inline-block;
     margin-bottom: 1rem;
-    padding: 0.25rem 1rem;
-    border: 1px solid #fff;
-    color: #fff;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
     text-decoration: none;
 }

--- a/ophirofox/content_scripts/gazetvanantwerpen.css
+++ b/ophirofox/content_scripts/gazetvanantwerpen.css
@@ -1,6 +1,17 @@
 .ophirofox-europresse {
-    display: block;
-    padding: 0.5rem;
-    border: 1px solid #d21d10;
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
     text-align: center;
+    text-decoration: none;
+}
+
+.ophirofox-modal-link {
+    display: block;
+    margin-top: 0;
+    padding: 0.5rem;
+    border-radius: 0;
 }

--- a/ophirofox/content_scripts/gazetvanantwerpen.js
+++ b/ophirofox/content_scripts/gazetvanantwerpen.js
@@ -1,34 +1,46 @@
 function extractKeywords() {
-    return document.querySelector("h1").textContent;
+    return document.querySelector("header h1").textContent;
 }
 
 let buttonAdded = false;
 
-async function createLink() {
-    const subscriptionElem = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
-    if (subscriptionElem && buttonAdded == false){
+async function createLink(elt) {
+    if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
-        subscriptionElem.after(a);
+        elt.after(a);
     }
 }
 
 async function onLoad() {
-    // Lien Europresse dans la modale au chargement de l'article
-    createLink();
+    // Lien Europresse dans le corps de l'article
+    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
+    const article_title = document.querySelector('header h1');
+    
+    if(paywall){
+        createLink(article_title);
+    }
 
-    // Lien Europresse dans le corps de l'article, une fois la modale fermée
+    // Lien Europresse dans la modale, au chargement
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
-            if(mutation.removedNodes.length > 0){
-                createLink();
-                buttonAdded = true;
+            if(mutation.type === 'childList'){
+                for(let node of mutation.addedNodes){
+                    const paywall_modal = document.querySelector('.cj-root');
+                    if(paywall_modal){
+                        const subscriptionForm = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
+                        createLink(subscriptionForm);
+                        buttonAdded = true;
+                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
+                        observer.disconnect();
+                    }
+                }
             }
         }
     };
 
-    const htmlElement = document.querySelector('.cj-root');
+    const htmlElement = document.querySelector('body');
     const observer = new MutationObserver(callback);
-    observer.observe(htmlElement, { childList: true});
+    observer.observe(htmlElement, { childList: true });
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/hetlaatstenieuws.css
+++ b/ophirofox/content_scripts/hetlaatstenieuws.css
@@ -1,5 +1,11 @@
 .ophirofox-europresse {
     display: block;
-    margin-top: 1rem;
+    width: 12vw;
+    margin: 1rem auto;
+    padding: 0.25rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
     text-align: center;
+    text-decoration: none !important;
 }

--- a/ophirofox/content_scripts/hetlaatstenieuws.js
+++ b/ophirofox/content_scripts/hetlaatstenieuws.js
@@ -25,6 +25,7 @@ async function onLoad() {
                 const newClassState = mutation.target.classList.contains('js-tm-backdrop-active');
                 if(classState !== newClassState){
                     addEuropresseButton();
+                    observer.disconnect();
                 }
             }
         }

--- a/ophirofox/content_scripts/hetnieuwsblad.css
+++ b/ophirofox/content_scripts/hetnieuwsblad.css
@@ -1,6 +1,17 @@
 .ophirofox-europresse {
-    display: block;
-    padding: 0.5rem;
-    border: 1px solid #0071c7;
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
     text-align: center;
+    text-decoration: none;
+}
+
+.ophirofox-modal-link {
+    display: block;
+    margin-top: 0;
+    padding: 0.5rem;
+    border-radius: 0;
 }

--- a/ophirofox/content_scripts/hetnieuwsblad.js
+++ b/ophirofox/content_scripts/hetnieuwsblad.js
@@ -1,34 +1,46 @@
 function extractKeywords() {
-    return document.querySelector("h1").textContent;
+    return document.querySelector("header h1").textContent;
 }
 
 let buttonAdded = false;
 
-async function createLink() {
-    const subscriptionElem = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
-    if (subscriptionElem && buttonAdded == false){
+async function createLink(elt) {
+    if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
-        subscriptionElem.after(a);
+        elt.after(a);
     }
 }
 
-async function onLoad() {
-    // Lien Europresse dans la modale au chargement de l'article
-    createLink();
-
-    // Lien Europresse dans le corps de l'article, une fois la modale fermée
+async function onLoad() {   
+    // Lien Europresse dans le corps de l'article
+    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
+    const article_title = document.querySelector('header h1');
+    
+    if(paywall){
+        createLink(article_title);
+    }
+    
+    // Lien Europresse dans la modale, au chargement
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
-            if(mutation.removedNodes.length > 0){
-                createLink();
-                buttonAdded = true;
+            if(mutation.type === 'childList'){
+                for(let node of mutation.addedNodes){
+                    const paywall_modal = document.querySelector('.cj-root');
+                    if(paywall_modal){
+                        const subscriptionForm = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
+                        createLink(subscriptionForm);
+                        buttonAdded = true;
+                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
+                        observer.disconnect();
+                    }
+                }
             }
         }
     };
-
-    const htmlElement = document.querySelector('.cj-root');
+        
+    const htmlElement = document.querySelector('body');
     const observer = new MutationObserver(callback);
-    observer.observe(htmlElement, { childList: true});
+    observer.observe(htmlElement, { childList: true });
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/knack.css
+++ b/ophirofox/content_scripts/knack.css
@@ -1,9 +1,11 @@
 .ophirofox-europresse {
     display: inline-block;
     margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    border: 1px solid #ee1c24;
-    color: #ee1c24;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
+    font-family: "Aeonik","Publica Slab","Helvetica","Arial",sans-serif;
     font-size: 1.5rem;
-    font-weight: bold;
+    text-decoration: none;
 }

--- a/ophirofox/content_scripts/levif.css
+++ b/ophirofox/content_scripts/levif.css
@@ -1,9 +1,11 @@
 .ophirofox-europresse {
     display: inline-block;
     margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    border: 1px solid #ee1c24;
-    color: #ee1c24;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
+    font-family: "Aeonik","Publica Slab","Helvetica","Arial",sans-serif;
     font-size: 1.5rem;
-    font-weight: bold;
+    text-decoration: none;
 }

--- a/ophirofox/content_scripts/theeconomist.css
+++ b/ophirofox/content_scripts/theeconomist.css
@@ -1,10 +1,9 @@
 .ophirofox-europresse{
     display: inline-block;
     margin-top: 1rem;
-    color: #e3120b;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
     text-decoration: none;
-}
-
-.ophirofox-europresse:hover{
-    text-decoration: underline;
 }

--- a/ophirofox/content_scripts/theeconomist.js
+++ b/ophirofox/content_scripts/theeconomist.js
@@ -14,10 +14,11 @@ async function onLoad() {
                 for(let node of mutation.addedNodes){
                     const subscriptionElem = document.querySelector('section[data-body-id*="cp"]');
                     if(node === subscriptionElem){
-                        const subtitle = document.querySelector('#new-article-template h2');
+                        const subtitle = document.querySelector('#new-article-template h1');
                         createLink().then(function(data){
                             subtitle.after(data);
                         });
+                        observer.disconnect();
                     }
                 }
             }
@@ -26,7 +27,7 @@ async function onLoad() {
     
     const htmlElement = document.querySelector('#new-article-template');
     const observer = new MutationObserver(callback);
-    observer.observe(htmlElement, { childList: true, subtree: true});
+    observer.observe(htmlElement, { childList: true, subtree: true });
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/trendstendances.css
+++ b/ophirofox/content_scripts/trendstendances.css
@@ -1,10 +1,11 @@
 .ophirofox-europresse {
     display: inline-block;
     margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    border: 1px solid #5cb4ab;
-    color: #5cb4ab;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
+    font-family: "Aeonik","Publica Slab","Helvetica","Arial",sans-serif;
     font-size: 1.5rem;
-    font-weight: bold;
     text-decoration: none;
 }

--- a/ophirofox/content_scripts/washingtonpost.css
+++ b/ophirofox/content_scripts/washingtonpost.css
@@ -3,6 +3,9 @@
     justify-content: center;
     margin: 1rem auto;
     padding: 0.25rem 1rem;
-    width: 40%;
-    border: 1px solid #1955a5;
+    width: 12vw;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000;
+    text-decoration: none;
 }


### PR DESCRIPTION
Bonjour,

Quelques corrections pour les quotidiens belges, UK et USA proposés récemment : 
- De Standaard, Het Nieuwsblad et la Gazet van Antwerpen : testé en local sur Google Chrome, le code précédant semblait fonctionner mais sur l'extension en ligne, le lien Lire sur Europresse ne s'affiche pas systématiquement, proposition de correction donc
- The Economist : Le bouton est après le sous-titre, mais il n'y en a parfois pas -> bouton après le h1
- Modification du style des boutons pour les rendre plus facilement repérables (De Morgen, De Standaard, Financial Times, Gazet van Antwerpen, Het Laatste Nieuws, Het Nieuwsblad, Knack, Le Vif, The Economist, Trends Tendances, Washington Post)

Bonne après-midi!