### PR TITLE
Update manifest.json - Ajout Lycée Clemenceau à Nantes

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -744,6 +744,10 @@
           "AUTH_URL": "https://nouveau.europresse.com/Login/Esidoc?sso_id=0940880W"
         },
         {
+          "name": "Lycée Clemenceau à Nantes",
+          "AUTH_URL": "https://nouveau.europresse.com/Login/Esidoc?sso_id=0440021J"
+        },
+        {
           "name": "Lycée International de l'Est Parisien",
           "AUTH_URL": "https://nouveau.europresse.com/Login/Esidoc?sso_id=0932638M"
         },


### PR DESCRIPTION
Le technicien réseau de mon établissement me dit qu'ils n'utilisent pas de proxy. 
J'ai donc uniquement ajouté le lien vers Europresse avec login sso.