### PR TITLE
Adaptation nouveau paywall GVA, HNB, De Standaard

### DIFF
--- a/ophirofox/content_scripts/destandaard.css
+++ b/ophirofox/content_scripts/destandaard.css
@@ -8,10 +8,3 @@
     text-align: center;
     text-decoration: none !important;
 }
-
-.ophirofox-modal-link {
-    display: block;
-    margin-top: 0;
-    padding: 0.5rem;
-    border-radius: 0;
-}

--- a/ophirofox/content_scripts/destandaard.js
+++ b/ophirofox/content_scripts/destandaard.js
@@ -1,36 +1,43 @@
-function extractKeywords() {
-    return document.querySelector("header h1").textContent;
-}
-
 let buttonAdded = false;
+const article_title = document.querySelector('header[data-testid="article-header"] h1');
+
+function extractKeywords() {
+    return article_title.textContent;
+}
 
 async function createLink(elt) {
     if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
         elt.after(a);
+        console.log(elt);
+        if(elt !== article_title){
+            //second link is in shadow dom context -> no access to stylesheet
+            a.style.display = "block"
+            a.style.width = "35%";
+            a.style.margin = "0.5rem auto";
+            a.style.padding = "0.5rem 0";
+            a.style.borderRadius = "0.3rem";
+            a.style.backgroundColor = "#ffc700";
+            a.style.color = "#000";
+            a.style.textDecoration = "none";
+            a.style.textAlign = "center";
+        }
     }
 }
 
 async function onLoad() {
-    // Lien Europresse dans le corps de l'article
-    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
-    const article_title = document.querySelector('header h1');
-    
-    if(paywall){
-        createLink(article_title);
-    }
-
-    // Lien Europresse dans la modale, au chargement
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
             if(mutation.type === 'childList'){
                 for(let node of mutation.addedNodes){
-                    const paywall_modal = document.querySelector('.cj-root');
-                    if(paywall_modal){
-                        const subscriptionForm = document.querySelector('[data-current-screen="CtaAuthPaying"] form');
-                        createLink(subscriptionForm);
+                    const paywall_modal = document.querySelector('.PSAPAG_root');
+                    if(paywall_modal){;
+                        const shadow_content = document.querySelector('.PSAPAG_root').shadowRoot;
+                        const modal_content = shadow_content.firstChild.lastChild;
+                        createLink(article_title);
+                        createLink(modal_content);
+
                         buttonAdded = true;
-                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
                         observer.disconnect();
                     }
                 }

--- a/ophirofox/content_scripts/gazetvanantwerpen.css
+++ b/ophirofox/content_scripts/gazetvanantwerpen.css
@@ -8,10 +8,3 @@
     text-align: center;
     text-decoration: none;
 }
-
-.ophirofox-modal-link {
-    display: block;
-    margin-top: 0;
-    padding: 0.5rem;
-    border-radius: 0;
-}

--- a/ophirofox/content_scripts/gazetvanantwerpen.js
+++ b/ophirofox/content_scripts/gazetvanantwerpen.js
@@ -1,36 +1,43 @@
-function extractKeywords() {
-    return document.querySelector("header h1").textContent;
-}
-
 let buttonAdded = false;
+const article_title = document.querySelector('header[data-testid="article-header"] h1');
+
+function extractKeywords() {
+    return article_title.textContent;
+}
 
 async function createLink(elt) {
     if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
         elt.after(a);
+        console.log(elt);
+        if(elt !== article_title){
+            //second link is in shadow dom context -> no access to stylesheet
+            a.style.display = "block"
+            a.style.width = "35%";
+            a.style.margin = "0.5rem auto";
+            a.style.padding = "0.5rem 0";
+            a.style.borderRadius = "0.3rem";
+            a.style.backgroundColor = "#ffc700";
+            a.style.color = "#000";
+            a.style.textDecoration = "none";
+            a.style.textAlign = "center";
+        }
     }
 }
 
 async function onLoad() {
-    // Lien Europresse dans le corps de l'article
-    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
-    const article_title = document.querySelector('header h1');
-    
-    if(paywall){
-        createLink(article_title);
-    }
-
-    // Lien Europresse dans la modale, au chargement
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
             if(mutation.type === 'childList'){
                 for(let node of mutation.addedNodes){
-                    const paywall_modal = document.querySelector('.cj-root');
-                    if(paywall_modal){
-                        const subscriptionForm = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
-                        createLink(subscriptionForm);
+                    const paywall_modal = document.querySelector('.PSAPAG_root');
+                    if(paywall_modal){;
+                        const shadow_content = document.querySelector('.PSAPAG_root').shadowRoot;
+                        const modal_content = shadow_content.firstChild.lastChild;
+                        createLink(article_title);
+                        createLink(modal_content);
+
                         buttonAdded = true;
-                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
                         observer.disconnect();
                     }
                 }

--- a/ophirofox/content_scripts/hetnieuwsblad.css
+++ b/ophirofox/content_scripts/hetnieuwsblad.css
@@ -8,10 +8,3 @@
     text-align: center;
     text-decoration: none;
 }
-
-.ophirofox-modal-link {
-    display: block;
-    margin-top: 0;
-    padding: 0.5rem;
-    border-radius: 0;
-}

--- a/ophirofox/content_scripts/hetnieuwsblad.js
+++ b/ophirofox/content_scripts/hetnieuwsblad.js
@@ -1,43 +1,50 @@
-function extractKeywords() {
-    return document.querySelector("header h1").textContent;
-}
-
 let buttonAdded = false;
+const article_title = document.querySelector('header[data-testid="article-header"] h1');
+
+function extractKeywords() {
+    return article_title.textContent;
+}
 
 async function createLink(elt) {
     if (elt && buttonAdded == false){
         const a = await ophirofoxEuropresseLink(extractKeywords());
         elt.after(a);
+        console.log(elt);
+        if(elt !== article_title){
+            //second link is in shadow dom context -> no access to stylesheet
+            a.style.display = "block"
+            a.style.width = "35%";
+            a.style.margin = "0.5rem auto";
+            a.style.padding = "0.5rem 0";
+            a.style.borderRadius = "0.3rem";
+            a.style.backgroundColor = "#ffc700";
+            a.style.color = "#000";
+            a.style.textDecoration = "none";
+            a.style.textAlign = "center";
+        }
     }
 }
 
-async function onLoad() {   
-    // Lien Europresse dans le corps de l'article
-    const paywall = document.querySelector('[data-cj-root="subscription-wall"]');
-    const article_title = document.querySelector('header h1');
-    
-    if(paywall){
-        createLink(article_title);
-    }
-    
-    // Lien Europresse dans la modale, au chargement
+async function onLoad() {
     const callback = (mutationList, observer) => {
         for (const mutation of mutationList) {
             if(mutation.type === 'childList'){
                 for(let node of mutation.addedNodes){
-                    const paywall_modal = document.querySelector('.cj-root');
-                    if(paywall_modal){
-                        const subscriptionForm = document.querySelector('[data-current-screen="StopEmailIdentification"] form');
-                        createLink(subscriptionForm);
+                    const paywall_modal = document.querySelector('.PSAPAG_root');
+                    if(paywall_modal){;
+                        const shadow_content = document.querySelector('.PSAPAG_root').shadowRoot;
+                        const modal_content = shadow_content.firstChild.lastChild;
+                        createLink(article_title);
+                        createLink(modal_content);
+
                         buttonAdded = true;
-                        subscriptionForm.nextElementSibling.classList.add('ophirofox-modal-link');
                         observer.disconnect();
                     }
                 }
             }
         }
     };
-        
+
     const htmlElement = document.querySelector('body');
     const observer = new MutationObserver(callback);
     observer.observe(htmlElement, { childList: true });


### PR DESCRIPTION
Bonjour,

Les 3 journaux (Gazet van Antwerpen, Het nieuwsblad et de Standaard) ont changé leur système de paywall, le lien europresse n'apparaissait plus. J'ai fait les modifs, normalement ça fonctionne (testé sur Google Chrome).

Bonne journée!