### PR TITLE
set Jekyll language to fr-FR

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+lang: fr-FR


### PR DESCRIPTION
Fix #246 