### PR TITLE
Improve add-on badges styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 Une extension pour navigateurs qui permet de lire la plupart des titres de presse, comme les articles du **Monde**, du **Figaro**, de **Libération** et du **Monde Diplomatique** avec son compte **Europresse**.
 
-[![Mozilla Firefox: download on mozilla addons](https://user-images.githubusercontent.com/552629/82738693-f4900f80-9d39-11ea-816c-1bddb73b6967.png)](https://github.com/lovasoa/ophirofox/releases/latest/download/ophirofox.xpi)
-[![Google Chrome: download on the chrome web store](https://user-images.githubusercontent.com/552629/104166652-661ceb00-53fb-11eb-91c1-2db0718db66f.png)](https://chrome.google.com/webstore/detail/ophirofox/mmmjkgckgcpankonbgbianpnfenbhodf)
+<p align="center">
+ <a href="https://github.com/lovasoa/ophirofox/releases/latest/download/ophirofox.xpi">
+  <img src="https://github.com/user-attachments/assets/eae883da-2669-4469-a61d-6a532a986f3b" alt="Obtenir l'extension pour Mozilla Firefox" style="vertical-align: middle;">
+ </a>
+ <a href="https://chrome.google.com/webstore/detail/ophirofox/mmmjkgckgcpankonbgbianpnfenbhodf">
+  <img src="https://user-images.githubusercontent.com/552629/104166652-661ceb00-53fb-11eb-91c1-2db0718db66f.png" alt="Obtenir l'extension pour Google Chrome sur le Chrome Web Store" style="vertical-align: middle;">
+ </a>
+</p>
 
 Comme illustré ci-dessous, l'extension ajoute un bouton **Lire sur Europresse** sur les articles réservés aux abonnés des journaux compatibles.
 


### PR DESCRIPTION
Improve add-on badges styling. Sadly the readme doesn't render well on github, but the website looks cleaner IMO :)

Only thing I'm not sure is if the `https://github.com/user-attachments/assets` url of the new firefox add-on badge is the right way to do it.