### PR TITLE
Update la-provence.js

### DIFF
--- a/ophirofox/content_scripts/la-provence.js
+++ b/ophirofox/content_scripts/la-provence.js
@@ -6,10 +6,10 @@ async function createLink() {
 
 
 function findPremiumBanner() {
-    const title = document.querySelector(".header-article-premium__stamp");
-    if (!title) return null;
-    const elems = title.parentElement.querySelectorAll("span");
-    return [...elems].find(d => d.textContent.includes("Article réservé aux abonnés"))
+    const array = document.querySelectorAll(".rev-margin-0.rev-text-xs-bold");
+    const reserve = Array.from(array).find(p => p.textContent.includes("Article réservé aux abonnés")); 
+    if (!reserve) return null;
+    return reserve
 }
 
 async function onLoad() {


### PR DESCRIPTION
Fixes #253 : button now displays well on Firefox, but somehow on my Europresse no articles of La Provence seem available.