### PR TITLE
Mise à jour pour Sciences Po Paris

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -783,7 +783,7 @@
         },
         {
           "name": "Sciences Po Paris",
-          "AUTH_URL": "https://acces-distant.sciencespo.fr/fork?https://nouveau.europresse.com/access/ip/default.aspx?un=politique2T_1"
+          "AUTH_URL": "https://catalogue-bibliotheque.sciencespo.fr/view/action/uresolver.do?operation=resolveService&package_service_id=20109524480005808&institutionId=5808&customerId=5800&VE=true"
         },
         {
           "name": "Télécom Paris",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -52,7 +52,7 @@
     , "https://nouveau-europresse-com.portail.psl.eu/*"
     , "https://nouveau-europresse-com.passerelle.univ-rennes1.fr/*"
     , "https://nouveau-europresse-com.ressources-electroniques.univ-lille.fr/*"
-    , "https://nouveau-europresse-com.acces-distant.sciencespo.fr/*"
+    , "https://nouveau-europresse-com.scpo.idm.oclc.org/*"
     , "https://nouveau-europresse-com.ressources.univ-poitiers.fr/*"
     , "https://nouveau-europresse-com.bibelec.univ-lyon2.fr/*"
     , "https://nouveau-europresse-com.gorgone.univ-toulouse.fr/*"


### PR DESCRIPTION
Le changement de proxy a rendu l'ancienne adresse obsolète

Cf fix #275 