### PR TITLE
BNF  only : arret sur images

### DIFF
--- a/ophirofox/content_scripts/arret-sur-images.css
+++ b/ophirofox/content_scripts/arret-sur-images.css
@@ -1,0 +1,10 @@
+.ophirofox-europresse {
+    background-color: #f05246;
+    border: 1px #f05246 solid;
+    padding: calc(0.25em - 1px) 0.5em !important;
+    color: #fff;
+    font-family: "Merriweather", serif;
+    font-weight: 900 !important;
+    font-style: italic !important;
+    text-transform: none !important;
+}

--- a/ophirofox/content_scripts/arret-sur-images.js
+++ b/ophirofox/content_scripts/arret-sur-images.js
@@ -1,0 +1,47 @@
+//Aknowledgment : arret-sur-images feature found already mostly done on https://github.com/Rohirrim03/ profile.
+//BNF : Bibliothèque Nationale de France
+
+/**@description create link to BNF mirror */
+async function createLink() {
+    const span = document.createElement("span");
+    span.textContent = "Lire avec BNF";
+    span.className = "sub-stamp-component etiquette ophirofox-europresse";
+
+    const a = document.createElement("a");
+    var newUrl = new URL(window.location);
+    newUrl.host = "www-arretsurimages-net.bnf.idm.oclc.org";
+    a.href = newUrl;
+
+    a.appendChild(span);
+
+    return a;
+}
+
+/**
+ * @description check DOM for article under paywall 
+ * @return {HTMLElement} DOM Premium Banner
+*/
+function findPremiumBanner() {
+    const articleContainer = document.querySelector(".article-content");
+    //check if page is a article
+    if (!articleContainer) return null;
+    const paywall = document.querySelector(".paywall-block");
+    const elems = paywall.querySelectorAll("mark");
+    
+    return [...elems].find(d => d.textContent.includes("réservé aux abonné.e.s"))
+}
+
+/**@description check for BNF users. If yes, create link button */
+async function onLoad() {
+    const config = await ophirofox_config;
+    if(config.name !== 'BNF') return;
+    
+    const reserve = findPremiumBanner();
+    if (!reserve) return;
+
+    reserve.parentElement.appendChild(await createLink());
+}
+
+setTimeout(function(){
+    onLoad().catch(console.error);
+}, 1000);

--- a/ophirofox/content_scripts/arret-sur-images.js
+++ b/ophirofox/content_scripts/arret-sur-images.js
@@ -19,16 +19,15 @@ async function createLink() {
 
 /**
  * @description check DOM for article under paywall 
- * @return {HTMLElement} DOM Premium Banner
+ * @return {HTMLElement} DOM Premium Banner and head of the article
 */
 function findPremiumBanner() {
-    const articleContainer = document.querySelector(".article-content");
-    //check if page is a article
-    if (!articleContainer) return null;
-    const paywall = document.querySelector(".paywall-block");
-    const elems = paywall.querySelectorAll("mark");
-    
-    return [...elems].find(d => d.textContent.includes("réservé aux abonné.e.s"))
+    const article = document.querySelector(".article");
+    if (!article) return null;
+    const elems = article.querySelectorAll("span, mark");
+    const textToFind = ["réservé aux abonné.e.s", "Réservé à nos abonné.e.s"];
+
+    return [...elems].filter(d => textToFind.some(text => d.textContent.includes(text)))        
 }
 
 /**@description check for BNF users. If yes, create link button */
@@ -39,7 +38,9 @@ async function onLoad() {
     const reserve = findPremiumBanner();
     if (!reserve) return;
 
-    reserve.parentElement.appendChild(await createLink());
+    for (const balise of reserve) {
+        balise.parentElement.appendChild(await createLink());
+    }
 }
 
 setTimeout(function(){

--- a/ophirofox/content_scripts/arret-sur-images.js
+++ b/ophirofox/content_scripts/arret-sur-images.js
@@ -1,15 +1,19 @@
 //Aknowledgment : arret-sur-images feature found already mostly done on https://github.com/Rohirrim03/ profile.
 //BNF : Bibliothèque Nationale de France
 
-/**@description create link to BNF mirror */
-async function createLink() {
+/**
+ * @description create link <a> to BNF mirror
+ * @param {string} AUTH_URL_ARRETSURIMAGES
+ */
+async function createLink(AUTH_URL_ARRETSURIMAGES) {
     const span = document.createElement("span");
     span.textContent = "Lire avec BNF";
     span.className = "sub-stamp-component etiquette ophirofox-europresse";
 
     const a = document.createElement("a");
-    var newUrl = new URL(window.location);
-    newUrl.host = "www-arretsurimages-net.bnf.idm.oclc.org";
+    var newUrl = new URL(window.location);//current page
+    newUrl.host = AUTH_URL_ARRETSURIMAGES //change only the domain name
+    newUrl.href
     a.href = newUrl;
 
     a.appendChild(span);
@@ -32,14 +36,14 @@ function findPremiumBanner() {
 
 /**@description check for BNF users. If yes, create link button */
 async function onLoad() {
-    const config = await ophirofox_config;
-    if(config.name !== 'BNF') return;
-    
+
+    const config = await configurationsSpecifiques(['BNF'])
+    if(!config) return;
     const reserve = findPremiumBanner();
     if (!reserve) return;
 
     for (const balise of reserve) {
-        balise.parentElement.appendChild(await createLink());
+        balise.parentElement.appendChild(await createLink(config.AUTH_URL_ARRETSURIMAGES));
     }
 }
 

--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -249,6 +249,16 @@ async function ophirofoxAskPermissions(partner_name) {
   if (!granted) throw new Error("Permission not granted");
 }
 
+/**
+ * @description check if user plugin config match website specific config
+ * @param {string[]} configNames names of partners in manifest.js
+ * @return {{AUTH_URL:string, name:string,AUTH_URL_NAMEOFWEBSITE:string}} current config with specific property as defined in manifest.js
+ */
+async function configurationsSpecifiques(configNames){
+  const config = await ophirofox_config;
+  if (configNames.find((name) => name === config.name)) return config
+}
+
 const missing_permissions = [];
 
 // Returns a list of permissions that must be asked for.

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -697,7 +697,8 @@
         },
         {
           "name": "BNF",
-          "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1"
+          "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1",
+          "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org" 
         },
         {
           "name": "Bibliothèque Publique d'Information (BPI)",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -650,6 +650,18 @@
       "css": [
         "content_scripts/challenges.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.arretsurimages.net/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/arret-sur-images.js"
+      ],
+      "css": [
+        "content_scripts/arret-sur-images.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
## [BNF developpement specifique](https://github.com/lovasoa/ophirofox/issues/22)
#22 

Ajout du site [arretsurimages](https://www.arretsurimages.net) pour les abonné.e.s BNF .
Le bouton s'affiche  en haut de l'article et sur le bandeau paywall en bas.

> je ne suis pas un expert front, ni js :  si vous voyez des optimisations possible, je suis prenneur.

## tests effectués
[exemple article payant arretSurImages](https://www.arretsurimages.net/articles/a-libe-les-methodes-du-directeur-inquietent-une-partie-de-la-redaction)
### firefox 
|type test| result |
|--|--|
|Partenaire europresse selectionné : BNF  |  le bouton s'affiche bien sur article payant |
|Partenaire europresse autre que BNF   | Le bouton ne s'affiche pas sur article payant |
| click button | Redirection vers mirroir bnf ok |
| Visuel du bouton | affichage ok sur mobile et pc  |