### PR TITLE
BNF only : accès à mediapart via bnf

### DIFF
--- a/ophirofox/content_scripts/mediapart.js
+++ b/ophirofox/content_scripts/mediapart.js
@@ -1,0 +1,48 @@
+
+/**
+ * @description create link <a> to BNF mirror
+ * @param {string} AUTH_URL_MEDIAPART
+ */
+async function createLink(AUTH_URL_MEDIAPART) {
+    const span = document.createElement("span");
+    span.textContent = "Lire avec BNF";
+
+    const a = document.createElement("a");
+    a.href = new URL(AUTH_URL_MEDIAPART);
+    a.appendChild(span);
+
+    return a;
+}
+
+/**
+ * @description check DOM for article under paywall 
+ * @return {HTMLElement} DOM Premium Banner and head of the article
+*/
+function findPremiumBanner() {
+    const article = document.querySelector(".news__body__center__container");
+    if (!article) return null;
+    const elems = article.querySelectorAll(".paywall-message");
+    console.log("elements",elems)
+    //labels not the same for mobile or PC display
+    const textToFind = ["réservée aux abonné·es", "réservé aux abonné·es"]
+
+    return [...elems].filter((balise) =>  textToFind.some((text) => balise.textContent.toLowerCase().includes(text))  )
+    
+}
+
+/**@description check for BNF users. If yes, create link button */
+async function onLoad() {
+
+    const config = await configurationsSpecifiques(['BNF'])
+    if(!config) return;
+    const reserve = findPremiumBanner();
+    if (!reserve) return;
+
+    for (const balise of reserve) {
+     balise.appendChild(await createLink(config.AUTH_URL_MEDIAPART))
+    }
+}
+
+setTimeout(function(){
+    onLoad().catch(console.error);
+}, 1000);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -305,6 +305,15 @@
     },
     {
       "matches": [
+        "https://www.mediapart.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/mediapart.js"
+      ]
+    },
+    {
+      "matches": [
         "https://www.ouest-france.fr/*"
       ],
       "js": [
@@ -698,7 +707,8 @@
         {
           "name": "BNF",
           "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1",
-          "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org" 
+          "AUTH_URL_ARRETSURIMAGES": "www-arretsurimages-net.bnf.idm.oclc.org",
+          "AUTH_URL_MEDIAPART": "https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/licence"
         },
         {
           "name": "Bibliothèque Publique d'Information (BPI)",


### PR DESCRIPTION
## [BNF developpement specifique](https://github.com/lovasoa/ophirofox/issues/22)
#22 

Ajout du site [mediapart](https://www.mediapart.fr/) pour les abonné.e.s BNF .
Le bouton s'affiche  sur le bandeau paywall de l'article.
Pas de redirection sur l'article mis en place. Le bouton redirige à l'acceuil du site miroir. Voir plus bas.

## tests effectués
[exemple article payant mediapart](https://www.mediapart.fr/journal/international/180125/etats-unis-l-arrivee-de-trump-un-grand-defi-pour-les-defenseurs-du-climat)
dans le cas ou l'utilisateur.ice n'est pas encore connecté.e à son compte BNF : 

### Problème de connection  partielle si redirection sur l'article

#### cas avec bouton redirige directement vers l'article sur le mirroir.
`https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/journal/international/180125/etats-unis-l-arrivee-de-trump-un-grand-defi-pour-les-defenseurs-du-climat`

1. Sur le site mediapart, en cliquant sur le bouton 'lire avec BNF' , on arrive sur l'ecran de connection BNF. 
2. après connection on est redirigé vers l'article sur le domaine mirroir.
3. On peut naviguer sur le site mirroir mediapart mais les articles sont toujours derrière paywall. Et on n'apparait pas comme connecté avec le compte BNF.

![site  mirroir mediapart sans compte enregistré](https://i.ibb.co/HTF11R1/Screenshot-from-2025-01-19-16-54-39.png)

#### cas avec bouton redirige vers le mirroir, sans redirection sur l'article.
`https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/licence`

1. Sur le site mediapart, en cliquant sur le bouton 'lire avec BNF' , on arrive sur l'ecran de connection BNF. 
2. après connection on est redirigé vers l'acceuil.
3. On peut naviguer sur le site mirroir mediapart, acceder aux articles, et on apparait comme connecté au compte BNF.

![site mirroir mediapart avec compte enregistré](https://i.ibb.co/bJzbgZF/Screenshot-from-2025-01-19-16-28-10.png)


Je pense qu'un traitement specifique est fait sur la page licence ``https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/licence` au moment de la connection bnf.
Du coup faudra se contenter pour l'instant d'un accès part l'acceuil du mirroir.