### PR TITLE
BNF only : accès à pressreader

### DIFF
--- a/ophirofox/content_scripts/pressreader.css
+++ b/ophirofox/content_scripts/pressreader.css
@@ -1,0 +1,16 @@
+.ophirofox-europresse {
+  visibility: visible !important;
+  position: fixed;
+  text-align: center;
+  width: 100%;
+  top: 0px;
+  left: 0px;
+  z-index: 50;
+}
+.ophirofox-europresse > a {
+  color: #fff !important;
+  padding: 1px 20px;
+  font-weight: 600;
+  background-color: #2bc48c;
+  border-radius: 25px;
+}

--- a/ophirofox/content_scripts/pressreader.js
+++ b/ophirofox/content_scripts/pressreader.js
@@ -1,0 +1,26 @@
+async function createLink(AUTH_URL) {
+    const div = document.createElement("div");
+    div.className = "ophirofox-europresse"
+    const a = document.createElement("a");
+    a.textContent = "Cliquez pour lire avec BNF"
+    var newUrl = new URL(window.location);//current page
+    newUrl.host = AUTH_URL //change only the domain name
+    a.href = newUrl;
+
+    div.appendChild(a);
+    return div;
+}
+
+/**
+ * @description website navigation without window reload.
+ */
+async function onLoad() {
+    const config = await configurationsSpecifiques(['BNF'])
+    if(!config) return;
+    //too much js dom updates everywere to choose a more specific DOM.element.
+    const element = document.querySelector('body');
+    if (!element) return;
+    element.insertAdjacentElement('beforeend', await createLink(config.AUTH_URL_PRESSREADER));
+}
+
+onLoad().catch(console.error)

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -662,6 +662,18 @@
       "css": [
         "content_scripts/arret-sur-images.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.pressreader.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/pressreader.js"
+      ],
+      "css": [
+        "content_scripts/pressreader.css"
+      ]
     }
   ],
   "browser_specific_settings": {
@@ -698,7 +710,8 @@
         {
           "name": "BNF",
           "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1",
-          "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org" 
+          "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org",
+          "AUTH_URL_PRESSREADER" : "www-pressreader-com.bnf.idm.oclc.org"
         },
         {
           "name": "Bibliothèque Publique d'Information (BPI)",


### PR DESCRIPTION
## [BNF developpement specifique](https://github.com/lovasoa/ophirofox/issues/22)
#22 

Ajout du site [pressreader](https://www.pressreader.com/) pour les abonné.e.s BNF .
Principe du site : version numérisé, de nombreuses dernière ou avant-dernière edition de journaux qui sortent en kiosque.

(Je galerai sur la redirection mediapart, du coup me suis dit, je fais rapidement, un autre plus facile. erf, ça s'est pas exactement passé comme prevu.)

pressReader a une navigation entièrement reactive sans reload de page. J'ai du selectionner la balise `<body>` , et mettre le bouton en fixed tout en haut de la page. Il saute sinon, avec toutes les modifications du DOM faites par le framework js du site.

Lien BNF prend en charge la redirection, via la première url lorsqu'on arrive sur le site. cependant, le lien ne sera pas update lors de la navigation (js based).
exemple : 
- je click sur un lien d'un moteur de recherche `https://www.pressreader.com/fr/catalog`
   - bouton 'lire avec BNF' redirigera vers le miroir/fr/catalog
- je navigue sur le site `https://www.pressreader.com/foryou`
  - bouton bouton 'lire avec BNF' redirigera  toujours vers le miroir/fr/catalog

Pas vraiment un problème, vu la manière de naviguer sur le site une fois connecté.
