### PR TITLE
BNF-only redirection mediapart

### DIFF
--- a/ophirofox/content_scripts/mediapart.js
+++ b/ophirofox/content_scripts/mediapart.js
@@ -1,60 +1,73 @@
-
 /**
  * @description create link <a> to BNF mirror
  * @param {string} AUTH_URL_MEDIAPART
  */
 async function createLink(AUTH_URL_MEDIAPART) {
-    const span = document.createElement("span");
-    span.textContent = "Lire avec BNF";
+  const span = document.createElement("span");
+  span.textContent = "Lire avec BNF";
 
-    const a = document.createElement("a");
-    a.href = new URL(window.location);
-    a.host = AUTH_URL_MEDIAPART
-    a.appendChild(span);
-
-    return a;
+  const a = document.createElement("a");
+  a.href = new URL(window.location);
+  a.host = AUTH_URL_MEDIAPART;
+  a.appendChild(span);
+  return a;
 }
 
 /**
- * @description check DOM for article under paywall 
+ * @description check DOM for article under paywall
  * @return {HTMLElement} DOM Premium Banner and head of the article
-*/
+ */
 function findPremiumBanner() {
-    const article = document.querySelector(".news__body__center__container");
-    if (!article) return null;
-    const elems = article.querySelectorAll(".paywall-message");
-    console.log("elements",elems)
-    //labels not the same for mobile or PC display
-    const textToFind = ["réservée aux abonné·es", "réservé aux abonné·es"]
+  const article = document.querySelector(".news__body__center__container");
+  if (!article) return null;
+  const elems = article.querySelectorAll(".paywall-message");
+  //labels not the same for mobile or PC display
+  const textToFind = ["réservée aux abonné·es", "réservé aux abonné·es"];
 
-    return [...elems].filter((balise) =>  textToFind.some((text) => balise.textContent.toLowerCase().includes(text))  )
-    
+  return [...elems].filter((balise) =>
+    textToFind.some((text) => balise.textContent.toLowerCase().includes(text))
+  );
 }
 
-/**@description check for BNF users. If yes, create link button */
+/**
+ * @description if not properly logged on the mirror website, fetch the login page
+ */
+function handleMediapartMirror(config) {
+  const navBar = document.querySelector("ul.nav__actions");
+  const spans = navBar.querySelectorAll("span");
+
+  let isNotConnected = Array.from(spans).find(
+    (elem) => elem.textContent == "Se connecter"
+  );
+  if (isNotConnected) {
+    //account name not found. fetch login page
+    const LOGIN_PAGE = new URL(
+      "licence",
+      "https://" + config.AUTH_URL_MEDIAPART
+    );
+    fetch(LOGIN_PAGE).then(() => window.location.reload());
+  }
+}
+
+async function handleMediapart(config) {
+  const reserve = findPremiumBanner();
+  if (!reserve) return;
+
+  for (const balise of reserve) {
+    balise.appendChild(await createLink(config.AUTH_URL_MEDIAPART));
+  }
+}
+
+/**@description check for users with mediapart access. If yes, create link button */
 async function onLoad() {
-
-    const config = await configurationsSpecifiques(['BNF'])
-    if(!config) return;
-    var newUrl = new URL(window.location);//current page
-    if (newUrl.host+'/' == 'www-mediapart-fr.bnf.idm.oclc.org/' ) {
-        const domNavigation = document.querySelector('ul.nav__actions')
-        const spans = domNavigation.querySelectorAll('span')
-        //search account name
-    let isFound =   Array.from(spans).find((elem) => elem.textContent == 'Bibliothèque Nationale de France')
-        if(!isFound){
-            console.log('is not found')
-            //account name not found. fetch login page
-            fetch("https://www-mediapart-fr.bnf.idm.oclc.org/licence").then(() => window.location.reload());
-        }
-    }else{
-        const reserve = findPremiumBanner();
-        if (!reserve) return;
-
-        for (const balise of reserve) {
-        balise.appendChild(await createLink(config.AUTH_URL_MEDIAPART))
-        }
-    }
+  const config = await configurationsSpecifiques(["BNF"]);
+  if (!config) return;
+  const currentPage = new URL(window.location);
+  if (currentPage.host == config.AUTH_URL_MEDIAPART) {
+    handleMediapartMirror(config);
+  } else {
+    handleMediapart(config);
+  }
 }
 
 onLoad().catch(console.error);

--- a/ophirofox/content_scripts/mediapart.js
+++ b/ophirofox/content_scripts/mediapart.js
@@ -8,7 +8,8 @@ async function createLink(AUTH_URL_MEDIAPART) {
     span.textContent = "Lire avec BNF";
 
     const a = document.createElement("a");
-    a.href = new URL(AUTH_URL_MEDIAPART);
+    a.href = new URL(window.location);
+    a.host = AUTH_URL_MEDIAPART
     a.appendChild(span);
 
     return a;
@@ -35,14 +36,25 @@ async function onLoad() {
 
     const config = await configurationsSpecifiques(['BNF'])
     if(!config) return;
-    const reserve = findPremiumBanner();
-    if (!reserve) return;
+    var newUrl = new URL(window.location);//current page
+    if (newUrl.host+'/' == 'www-mediapart-fr.bnf.idm.oclc.org/' ) {
+        const domNavigation = document.querySelector('ul.nav__actions')
+        const spans = domNavigation.querySelectorAll('span')
+        //search account name
+    let isFound =   Array.from(spans).find((elem) => elem.textContent == 'Bibliothèque Nationale de France')
+        if(!isFound){
+            console.log('is not found')
+            //account name not found. fetch login page
+            fetch("https://www-mediapart-fr.bnf.idm.oclc.org/licence").then(() => window.location.reload());
+        }
+    }else{
+        const reserve = findPremiumBanner();
+        if (!reserve) return;
 
-    for (const balise of reserve) {
-     balise.appendChild(await createLink(config.AUTH_URL_MEDIAPART))
+        for (const balise of reserve) {
+        balise.appendChild(await createLink(config.AUTH_URL_MEDIAPART))
+        }
     }
 }
 
-setTimeout(function(){
-    onLoad().catch(console.error);
-}, 1000);
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -306,7 +306,8 @@
     },
     {
       "matches": [
-        "https://www.mediapart.fr/*"
+        "https://www.mediapart.fr/*",
+        "https://www-mediapart-fr.bnf.idm.oclc.org/*"
       ],
       "js": [
         "content_scripts/config.js",
@@ -721,7 +722,7 @@
           "name": "BNF",
           "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1",
           "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org",
-          "AUTH_URL_MEDIAPART": "https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/licence",
+          "AUTH_URL_MEDIAPART": "www-mediapart-fr.bnf.idm.oclc.org/",
           "AUTH_URL_PRESSREADER" : "www-pressreader-com.bnf.idm.oclc.org"
         },
         {

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -722,7 +722,7 @@
           "name": "BNF",
           "AUTH_URL": "https://bnf.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000067U_1",
           "AUTH_URL_ARRETSURIMAGES" : "www-arretsurimages-net.bnf.idm.oclc.org",
-          "AUTH_URL_MEDIAPART": "www-mediapart-fr.bnf.idm.oclc.org/",
+          "AUTH_URL_MEDIAPART": "www-mediapart-fr.bnf.idm.oclc.org",
           "AUTH_URL_PRESSREADER" : "www-pressreader-com.bnf.idm.oclc.org"
         },
         {


### PR DESCRIPTION
# redirection vers l'article lié du mirroir mediapart

Autre solution pour verifier la connection au mirroir (la nuit porte conseil). Checker si le nom du compte BNF est present sur la page ou non

- redirection
- fetch de la page login si non connecté
- suppression du setTimeout

@JohnCytron j'ai reçu ton message en mail, meme si j'arrive pas à le retrouver sur l'interface github ^^
Je test un peu plus, mais ça devrait regler ton problème de login. En incognito meme version de firefox, le login se faisait bien pour moi avant cette pr. 

PR en draft le temps que je remette ça au propre. Et teste un peu.

