### PR TITLE
WIP ajout usine nouvelle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Voici la liste triée par ordre alphabétique :
 - [Les Échos](https://www.lesechos.fr)
 - [Mediapart (nécessite un abonnement BNF)](https://www.mediapart.fr/)
 - [Télérama (Magazine en PDF)](https://www.telerama.fr/kiosque/telerama)
+- [L'Usine Nouvelle](https://www.usinenouvelle.com/)
   
 ### Presse régionale
   - [Corse Matin](https://www.corsematin.com/)

--- a/ophirofox/content_scripts/usineNouvelle.js
+++ b/ophirofox/content_scripts/usineNouvelle.js
@@ -1,19 +1,10 @@
-/**
- * 
- * @description titles don't match between europress and origin site. Use lead Paragraph instead.
- * @return truncated first part of paragraph. Dont cut off words
- */
 function extractKeywords() {
-    let edito =  document.querySelector(".editoTitleType9 > p").textContent;
-    console.log('edito length', edito.length)
-    if (edito.length > 75){
-        edito = edito.substring(0, edito.lastIndexOf(' ', 75));
-    }
-    return edito
+    return document.querySelector(".editoSocialBar__item[data-title]").dataset.title
 }
 
 async function createLink() {
     const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.style = 'font-family: "arimo-bold",Arial,Helvetica,sans-serif; border-bottom: 2px solid #000; margin-left : 1rem'
     return a;
 }
 

--- a/ophirofox/content_scripts/usineNouvelle.js
+++ b/ophirofox/content_scripts/usineNouvelle.js
@@ -1,0 +1,34 @@
+/**
+ * 
+ * @description titles don't match between europress and origin site. Use lead Paragraph instead.
+ * @return truncated first part of paragraph. Dont cut off words
+ */
+function extractKeywords() {
+    let edito =  document.querySelector(".editoTitleType9 > p").textContent;
+    console.log('edito length', edito.length)
+    if (edito.length > 75){
+        edito = edito.substring(0, edito.lastIndexOf(' ', 75));
+    }
+    return edito
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+function findPremiumBanner() {
+    const div = document.querySelector(".epPayWallTop");
+    if (!div) return null;
+    console.log('all div', div)
+    console.log('last child', div.lastElementChild)
+    return elem = div.lastElementChild;
+}
+
+async function onLoad() {
+    const premiumBanner = findPremiumBanner();
+    if (!premiumBanner) return;
+    premiumBanner.after(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -686,6 +686,15 @@
       "css": [
         "content_scripts/pressreader.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.usinenouvelle.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/usineNouvelle.js"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
# Ajout Usine nouvelle

Suite aux difficultées exposées dans cette issue : https://github.com/lovasoa/ophirofox/issues/262  recupere le texte du chapeau de l'article, plutot que le titre. 

Ne recupere que les  75 premiers charactères (valeur arbitraire) du chapeau, sans couper les mots. Pour que la recherche europress fonctionne. Exemple [mecanumeric redressement judicaire](https://www.usinenouvelle.com/article/fleuron-industriel-du-tarn-l-entreprise-mecanumeric-placee-en-redressement-judiciaire.N2227246)

## difficultée rencontrée : la requete est transmise avec le mot clef TIT_HEAD
> TIT_HEAD= L entreprise Mécanuméric spécialisée dans la conception la

europresse ne trouve donc rien car ce n'est pas un titre. Par contre l'article est bien retrouvé avec le mot clef TEXT
> TEXT= L entreprise Mécanuméric spécialisée dans la conception la
 
la valeur TIT_HEAD=   est rajouté dans [content_scripts/europresse_search.js#L51](https://github.com/lovasoa/ophirofox/blob/master/ophirofox/content_scripts/europresse_search.js#L51)

```
function loadRead(){
  //do stuff ...
  keyword_field.value = 'TIT_HEAD=' + keywords;
}
```
@Write As- tu une approches à recommender ? 
Je serai parti sur  
- dans [config.js](https://github.com/lovasoa/ophirofox/blob/master/ophirofox/content_scripts/config.js)  nouvelle fonction ophirofoxEuropresseInnerTextLink
  - type de ophirofox_request_type :  `'type': 'readInnerText'`
- dans [europress_search.js](https://github.com/lovasoa/ophirofox/blob/master/ophirofox/content_scripts/europresse_search.js) update de fonction onLoad()
  -  rajout de `if (type == "readInnerText") {await loadReadInnerText();}`
- creation method loadReadInnerText() avec keyWord TEXT=

