### PR TITLE
Ajout El-Pais pour le pack optionnel Lexis Nexis

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Voici la liste triée par ordre alphabétique :
   - [Courrier international](https://www.courrierinternational.com)
   - [De Morgen (Belgique - néerlandophone)](https://www.demorgen.be/)
   - [De Standaard (Belgique - néerlandophone)](https://www.standaard.be/)
+  - [el-pais (Espagne - nécessite le pack  europress Lexis Nexis)](https://www.standaard.be/)
   - [Financial Times (Royaume-Uni)](https://www.ft.com/)
   - [Gazet van Antwerpen (Belgique - néerlandophone)](https://www.gva.be/)
   - [Het Laatste Nieuws (Belgique - néerlandophone)](https://www.hln.be/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Voici la liste triée par ordre alphabétique :
   - [Courrier international](https://www.courrierinternational.com)
   - [De Morgen (Belgique - néerlandophone)](https://www.demorgen.be/)
   - [De Standaard (Belgique - néerlandophone)](https://www.standaard.be/)
-  - [el-pais (Espagne - nécessite le pack  europress Lexis Nexis)](https://www.standaard.be/)
+  - [El Pais (Espagne - nécessite le pack  europress Lexis Nexis)](https://www.standaard.be/)
   - [Financial Times (Royaume-Uni)](https://www.ft.com/)
   - [Gazet van Antwerpen (Belgique - néerlandophone)](https://www.gva.be/)
   - [Het Laatste Nieuws (Belgique - néerlandophone)](https://www.hln.be/)

--- a/ophirofox/content_scripts/el-pais.css
+++ b/ophirofox/content_scripts/el-pais.css
@@ -1,0 +1,8 @@
+.ophirofox-europresse {
+    padding: .5rem;
+  font-size: .75rem;
+  min-width: 10rem;
+  background: #f7cf3c;
+  font-weight: 700;
+  font-family: MarcinAntB,sans-serif;
+}

--- a/ophirofox/content_scripts/el-pais.js
+++ b/ophirofox/content_scripts/el-pais.js
@@ -1,0 +1,48 @@
+let buttonAdded = false;
+function extractKeywords() {
+  let currentURL = new URL(window.location)
+  // get title at the end of URL pathname. 
+  // Remove noise characters, and make it search-ready for europress
+  const result = currentURL.pathname.split("/").pop().replace(/-|\.html$/g, ' ').trim()
+  return  result;
+}
+
+async function createLink(title) {
+  if (title && buttonAdded == false) {
+    const div = document.createElement('div')
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.textContent = 'Lire sur europresse (Lexis Nexis)'
+    div.appendChild(a);
+    title.after(div)
+  }
+}
+
+async function onLoad() {
+  console.log("ophirofox loaded");
+
+  const callback = (mutationList, observer) => {
+    for (const mutation of mutationList) {
+      if (mutation.type === "childList") {
+        for (let node of mutation.addedNodes) {
+
+          const paywall = document.querySelector("#ctn_freemium_article");
+          if (paywall == null) return;
+
+          if (buttonAdded == false) {
+            const article = document.querySelector(".a_s_b");
+            createLink(article);
+
+            const title = document.querySelector("h1");
+            createLink(title);
+          }
+          buttonAdded = true;
+          observer.disconnect();
+        }
+      }
+    }
+  };
+  const htmlElement = document.querySelector("article");
+  const observer = new MutationObserver(callback);
+  observer.observe(htmlElement, { childList: true, subtree: true });
+}
+onLoad().catch(console.error);

--- a/ophirofox/content_scripts/el-pais.js
+++ b/ophirofox/content_scripts/el-pais.js
@@ -1,30 +1,32 @@
 let buttonAdded = false;
 function extractKeywords() {
-  let currentURL = new URL(window.location)
-  // get title at the end of URL pathname. 
+  let currentURL = new URL(window.location);
+  // get title at the end of URL pathname.
   // Remove noise characters, and make it search-ready for europress
-  const result = currentURL.pathname.split("/").pop().replace(/-|\.html$/g, ' ').trim()
-  return  result;
+  const result = currentURL.pathname
+    .split("/")
+    .pop()
+    .replace(/-|\.html$/g, " ")
+    .trim();
+  return result;
 }
 
 async function createLink(title) {
   if (title && buttonAdded == false) {
-    const div = document.createElement('div')
+    const div = document.createElement("div");
     const a = await ophirofoxEuropresseLink(extractKeywords());
-    a.textContent = 'Lire sur europresse (Lexis Nexis)'
+    a.textContent = "Lire sur europresse (Lexis Nexis)";
     div.appendChild(a);
-    title.after(div)
+    title.after(div);
   }
 }
 
 async function onLoad() {
   console.log("ophirofox loaded");
-
   const callback = (mutationList, observer) => {
     for (const mutation of mutationList) {
       if (mutation.type === "childList") {
         for (let node of mutation.addedNodes) {
-
           const paywall = document.querySelector("#ctn_freemium_article");
           if (paywall == null) return;
 

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -695,6 +695,18 @@
         "content_scripts/config.js",
         "content_scripts/usineNouvelle.js"
       ]
+    },
+    {
+      "matches": [
+        "https://elpais.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/el-pais.js"
+      ],
+      "css":[
+        "content_scripts/el-pais.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
# El-Pais pour le pack optionnel Lexis Nexis

pas de gestion de visibilité du bouton, mais j'ai rajouté une precision dans le label  
> Lire sur europresse (Lexis Nexis)

Cas particuliers non gérés pour l'instant où la recherche peut peter :  
- presence de guillemets dans le titre 
- cas d'un tiret dans le titre (nom composé ou  certaines villes) 

