### PR TITLE
Update manifest.json

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -111,6 +111,8 @@
     , "https://nouveau-europresse-com.bpi.idm.oclc.org/*"
     , "https://nouveau-europresse-com.eztest.biblio.univ-evry.fr/*"
     , "https://nouveau-europresse-com.ezproxy.uclouvain.be/*"
+    , "https://nouveau-europresse-com.iepnomade-2.grenet.fr/*"
+    , "https://nouveau-europresse-com.eu1.proxy.openathens.net/*"
   ],
   "background": {
     "scripts": [
@@ -1170,6 +1172,14 @@
         {
           "name": "E-medi@s Savoie Mont Blanc",
           "AUTH_URL": "https://e-medias.biblio7374.fr/Portal/ASSARedirect.ashx?url=https://nouveau.europresse.com/access/httpref/default.aspx?un=PringyU_2"
+        },
+        {
+          "name": "Science Po Grenoble",
+          "AUTH_URL": "http://iepnomade.grenet.fr/login?url=http://nouveau.europresse.com/access/ip/default.aspx?un=IEPT_1"
+        },
+        {
+          "name": "ENTPE",
+          "AUTH_URL": "https://login.openathens.net/saml/2/sso/entpe.fr/o/81387240/c/proxy.openathens.net?SAMLRequest=jZJRb9owFIX%2FiuX3xI6JSWIRKlY0DanbUEn7sDfjXIqlYGe%2BTlf%2B%2FQIMqZW6qu%2F3nnN0vjO7eTl05BkCWu9qmqWcEnDGt9Y91fSh%2BZqUlGDUrtWdd1BT5%2BnNfIb60PVqMcS9u4ffA2AkC0QIcVS59Q6HA4QNhGdr4OH%2Brqb7GHtUjHX%2Bybq0D%2F7lmPoenI57cJg6iOwkyQTTBhloI4q2hERAO0lyucuTkhd5wrdSm2mb7yZaUrIcXe2ocA7%2B1uB9aUTPwMUe0l1gnpXZpCxEzplh7wWiZLWs6dZk00Ia3mY7k8tWVkIK3kJlSs7LTFbjFeIAK3fqKNZUcCETPkl43nCh5FTJKhVV8YuSdfDRG999se5S7hCc8hotKqcPgCoatVl8v1Mi5Wp7OUL1rWnWyfrnpqHk8QpJnCCN2ByqM4ePpfp%2FvvRCTZ3zhlf%2FH7%2FrK1Y6v3b8f3xjuzYeP8Vvxl6luQ7qx2i%2FWq59Z82RLLrO%2F7kNoOM4u4yy%2BeXl7ezmfwE%3D&RelayState=https%3A%2F%2Fnouveau-europresse-com.proxy.openathens.net%2Faccess%2Fip%2Fdefault.aspx%3Fun%3DENTPET_1"
         }
       ]
     }


### PR DESCRIPTION
Ajouté Science Po Grenoble et l'ENTPE.
Pour l'ENTPE je n'ai pas pu avoir de lien plus court, l'URL de connexion est d'abord https://biblioguides.entpe.fr/europresse puis il y a une redirection vers cette adresse surprenamment longue.