### PR TITLE
Fixe la page de recherche qui tourne en boucle quand aucun résultat n'est trouvé

### DIFF
--- a/ophirofox/content_scripts/europresse_search.js
+++ b/ophirofox/content_scripts/europresse_search.js
@@ -143,7 +143,6 @@ async function onLoad() {
         console.log("(Ophirofox) No consumable found.");
         if (path.startsWith("/Search/Result")) {
             const numberOfResul = document.querySelector('.resultOperations-count').textContent;
-            console.log("numberOfResul", numberOfResul);
             if (numberOfResul === '1') {
                 const auto_open_link = await getAutoOpenOption();
                 if (auto_open_link) {


### PR DESCRIPTION
Navré de ne pas avoir vu cela dès le dépars