### PR TITLE
Affichage bouton sur pages speciales libération

### DIFF
--- a/ophirofox/content_scripts/liberation.js
+++ b/ophirofox/content_scripts/liberation.js
@@ -15,7 +15,7 @@ async function createLink(publishedTime) {
 }
 
 function findPremiumBanner() {
-  const anchor = document.querySelector('div.TypologyArticle__BlockPremium-sc-1vro4tp-2');
+  const anchor = document.querySelector('div.TypologyArticle__BlockPremium-sc-1vro4tp-2 , div.jahSgQ');
   if (!anchor) {
     return;
   }


### PR DESCRIPTION
# Correction bug  d'affichage liberation

issue #348  
## tests via firefox 138.0.1 :
- button s'affiche toujours pour les articles classiques
- button s'affiche bien pour les deux articles en exemple dans l'issue github