### PR TITLE
Ajout d'une fonctionnalité optionnel, de menu de recherche contextuel…

### DIFF
--- a/ophirofox/content_scripts/config.js
+++ b/ophirofox/content_scripts/config.js
@@ -15,7 +15,10 @@ function getOphirofoxConfigByName(search_name) {
 
 const DEFAULT_SETTINGS = {
   partner_name: "Pas d'intermédiaire",
+  partner_AUTH_URL: "https://nouveau.europresse.com/Login",
   open_links_new_tab: false,
+  auto_open_link: false,
+  add_search_menu: false,
 };
 
 let current_settings = DEFAULT_SETTINGS;
@@ -42,6 +45,8 @@ async function getSettings() {
  * @param {typeof DEFAULT_SETTINGS} settings
  */
 async function setSettings(settings) {
+  let ophirofoxConfig = await getOphirofoxConfig()
+  settings.partner_AUTH_URL = ophirofoxConfig.AUTH_URL;
   current_settings = settings;
   return new Promise((accept) => {
     chrome.storage.local.set(

--- a/ophirofox/content_scripts/europresse_search.js
+++ b/ophirofox/content_scripts/europresse_search.js
@@ -125,7 +125,8 @@ async function loadReadPDF(){
 }
 
 async function onLoad() {
-    ophirofoxRealoadOnExpired();
+    await getSettings();
+    await ophirofoxRealoadOnExpired();
     const path = window.location.pathname;
 
     if (!(
@@ -144,9 +145,7 @@ async function onLoad() {
         if (path.startsWith("/Search/Result")) {
             const numberOfResul = document.querySelector('.resultOperations-count').textContent;
             if (numberOfResul === '1') {
-                const auto_open_link = await getAutoOpenOption();
-                if (auto_open_link) {
-
+                if (current_settings.auto_open_link) {
                     await readWhenOnlyOneResult();
                 }
             } else if (numberOfResul === '0') {
@@ -182,11 +181,11 @@ async function onLoad() {
     }
 }
 
-function ophirofoxRealoadOnExpired() {
+async function ophirofoxRealoadOnExpired() {
     const params = new URLSearchParams(window.location.search)
-    if (params.get("ErrorCode") == "4000112") {
-        // session expirée
-        window.history.back();
+    if (params.get("ErrorCode") === "4000112") {
+        // session expiréele
+        window.location = current_settings.partner_AUTH_URL;
     }
 }
 
@@ -218,19 +217,29 @@ function readWhenOnlyOneResult() {
 }
 
 const DEFAULT_SETTINGS = {
-    auto_open_link: false
+    partner_name: "Pas d'intermédiaire",
+    partner_AUTH_URL: "https://nouveau.europresse.com/Login",
+    open_links_new_tab: false,
+    auto_open_link: false,
+    add_search_menu: false,
 };
+
+let current_settings = DEFAULT_SETTINGS;
+
 const OPHIROFOX_SETTINGS_KEY = "ophirofox_settings";
 
-async function getAutoOpenOption() {
+/**
+ * @returns {Promise<typeof DEFAULT_SETTINGS>}
+ */
+async function getSettings() {
     const key = OPHIROFOX_SETTINGS_KEY;
     return new Promise((accept) => {
         chrome.storage.local.get([key], function (result) {
             if (result.hasOwnProperty(key)) {
                 current_settings = JSON.parse(result[key]);
-                accept(current_settings.auto_open_link);
+                accept(current_settings);
             }
-            else accept(DEFAULT_SETTINGS.auto_open_link);
+            else accept(DEFAULT_SETTINGS);
         });
     });
 }

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -12,6 +12,7 @@
     "page": "settings/options_ui.html"
   },
   "permissions": [
+    "contextMenus",
     "storage",
     "scripting",
     "webRequest",

--- a/ophirofox/settings/options_ui.html
+++ b/ophirofox/settings/options_ui.html
@@ -85,7 +85,7 @@
   <body>
     <form id="configuration">
       <button id="missing_permissions" hidden type="button">
-        Autoriser l'accès à un partenaire Europresse
+        Autoriser l'accès à Europresse
       </button>
       <fieldset>
         <legend>Général</legend>

--- a/ophirofox/settings/options_ui.html
+++ b/ophirofox/settings/options_ui.html
@@ -85,10 +85,14 @@
   <body>
     <form id="configuration">
       <button id="missing_permissions" hidden type="button">
-        Autoriser l'accès à Europresse
+        Autoriser l'accès à un partenaire Europresse
       </button>
       <fieldset>
         <legend>Général</legend>
+        <label id="add_search_label" hidden >
+          <input type="checkbox" id="add_search_menu">
+          Ajouter un menu contextuel pour rechercher les textes sélectionnés sur Europresse
+        </label>
         <label>
           <input type="checkbox" id="open_links_new_tab">
           Ouvrir les liens Europresse dans un nouvel onglet

--- a/ophirofox/settings/options_ui.js
+++ b/ophirofox/settings/options_ui.js
@@ -4,6 +4,7 @@ const search = document.getElementById("partner_search");
 const missing_permissions_btn = document.getElementById("missing_permissions");
 const openLinksCheckbox = document.getElementById("open_links_new_tab");
 const autoOpenLinkCheckbox = document.getElementById("auto_open_link");
+const addSearchMenuCheckbox = document.getElementById("add_search_menu");
 
 let settings = {};
 
@@ -43,6 +44,7 @@ getSettings().then((retrievedSettings) => {
   reCheckPermissions(settings.partner_name);
   openLinksCheckbox.checked = settings.open_links_new_tab || false;
   autoOpenLinkCheckbox.checked = settings.auto_open_link || false;
+  addSearchMenuCheckbox.checked = settings.add_search_menu || false;
 });
 
 // Gestion des modifications de la case à cocher
@@ -53,6 +55,11 @@ openLinksCheckbox.onchange = () => {
 
 autoOpenLinkCheckbox.onchange = () => {
   settings.auto_open_link = autoOpenLinkCheckbox.checked;
+  setSettings(settings);
+};
+
+addSearchMenuCheckbox.onchange = () => {
+  settings.add_search_menu = addSearchMenuCheckbox.checked;
   setSettings(settings);
 };
 
@@ -72,3 +79,16 @@ search.oninput = () => {
     partner.hidden = !partner_name.includes(search_term);
   });
 };
+
+// ======== Si le navigateur fonctionne sous Android l'on ne montre pas l'option menu recherche ========
+async function onLoad(){
+  if (isNotAndroid()) {
+    document.getElementById("add_search_label").style.display = "block";
+  }
+}
+
+function isNotAndroid() {
+  return !/Android/.test(navigator.userAgent);
+}
+
+onLoad().catch(console.error);


### PR DESCRIPTION
Ajout d'une fonctionnalité optionnel, de menu de recherche contextuel d'une sélection de texte sur Europresse.

+ Amélioration du comportement en cas d'erreur "4000112" : (Fonctionne parfaitement pour la BNF, mais à peut-être besoin d'être testé pour les autres partenaires)