### PR TITLE
ajout journal jeuneAfrique

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Voici la liste triée par ordre alphabétique :
   - [Gazet van Antwerpen (Belgique - néerlandophone)](https://www.gva.be/)
   - [Het Laatste Nieuws (Belgique - néerlandophone)](https://www.hln.be/)
   - [Het Nieuwsblad (Belgique - néerlandophone)](https://www.nieuwsblad.be/)
+  - [Jeune Afrique](https://www.jeuneafrique.com/)
   - [Knack (Belgique - néerlandophone)](https://www.knack.be/)
   - [L'Avenir (Belgique)](https://www.lavenir.net/)
   - [L'Orient-Le Jour (Liban)](https://www.lorientlejour.com/)

--- a/ophirofox/content_scripts/jeuneAfrique.css
+++ b/ophirofox/content_scripts/jeuneAfrique.css
@@ -1,0 +1,9 @@
+.ophirofox-europresse {
+    display: inline-block;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
+    text-align: center;
+    text-decoration: none;
+}

--- a/ophirofox/content_scripts/jeuneAfrique.js
+++ b/ophirofox/content_scripts/jeuneAfrique.js
@@ -1,0 +1,13 @@
+async function createLink() {
+    const a = await ophirofoxEuropresseLink();
+    a.className = "ophirofox-europresse";
+    return a;
+}
+
+async function onLoad() {
+    const header = document.querySelector(".article__header");
+    if (!header) return;
+    header.appendChild(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -800,6 +800,18 @@
       "css":[
         "content_scripts/investir-lesechos.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.jeuneafrique.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/jeuneAfrique.js"
+      ],
+      "css": [
+        "content_scripts/jeuneAfrique.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
# ajout journal jeune Afrique

ajout de l'integration pour le site https://www.jeuneafrique.com/
#353

- un seul bouton 'lire sur europresse' sur le header de l'article. Pas trouvé d'ancre propre pour mettre un bouton facilement dans le paywall en bas des articles.
- affichage testé en vue mobile et ordi portable
- testé avec compte europress bnf et  sur firefox 138.0.1 
- bouton s'affiche aussi sur les articles au [format enquete](https://www.jeuneafrique.com/1699621/politique/la-chambre-rouge-de-wagner-quand-les-mercenaires-russes-exhibent-leurs-crimes-sur-telegram/)