### PR TITLE
Ajout Le Berry republicain

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Voici la liste triée par ordre alphabétique :
   - [L'Orient-Le Jour (Liban)](https://www.lorientlejour.com/)
   - [La DH (Belgique)](https://www.dhnet.be/)
   - [La Libre Belgique](https://www.lalibre.be/)
+  - [Le Berry Républicain](https://www.leberry.fr/)
   - [Le Soir (Belgique)](https://www.lesoir.be)
   - [Le Temps (Suisse)](https://www.letemps.ch/)
   - [Le Vif (Belgique)](https://www.levif.be/)

--- a/ophirofox/content_scripts/leberry.css
+++ b/ophirofox/content_scripts/leberry.css
@@ -1,0 +1,9 @@
+.ophirofox-europresse {
+    display: inline-block;
+    padding: 0.25rem 1rem;
+    border-radius: 0.3rem;
+    background-color: #ffc700;
+    color: #000 !important;
+    text-align: center;
+    text-decoration: none;
+}

--- a/ophirofox/content_scripts/leberry.js
+++ b/ophirofox/content_scripts/leberry.js
@@ -1,0 +1,66 @@
+//Flag pour ne pas créer multiples bouttons par page.
+let isLinkCreated = false
+
+function extractKeywords() {
+    const metaElement = document.querySelector('meta[name="og:title"]');
+    return metaElement;
+}
+
+async function createLink() {
+    if(isLinkCreated) return
+    isLinkCreated = true
+    
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.className = "ophirofox-europresse";
+    const paywall = document.querySelector(".bg-premium-light")
+    paywall.appendChild(a);
+    return a;
+}
+
+// Variable pour stocker le timer de surveillance post-injection
+let checkTimer = null;
+function watchUrlChanges() {
+    let currentUrl = window.location.href;
+    
+    // Surveiller les changements d'URL
+    setInterval(() => {
+        if (currentUrl !== window.location.href) {
+            currentUrl = window.location.href;
+            isLinkCreated = false
+            
+            // Arrêter la surveillance post-injection
+            if (checkTimer) {
+                clearInterval(checkTimer);
+                checkTimer = null;
+            }
+            
+            // Relancer l'observer quand l'URL change
+            startObserver();
+        }
+    }, 500); // Vérifier toutes les 500ms
+}
+
+function startObserver(){
+    const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+            if(mutation.type === 'attributes' && mutation.attributeName === 'id'){
+                if(!isLinkCreated){
+                    createLink()
+                }
+                observer.disconnect();
+            }
+        }
+    };
+    const htmlElement = document.querySelector('body');
+    //paywall balise
+    const classState = htmlElement.classList.contains('.bg-premium-light');
+    const observer = new MutationObserver(callback);
+    observer.observe(htmlElement, { attributes: true, subtree: true });
+}
+
+async function onLoad() {
+    startObserver()
+    watchUrlChanges()
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -812,6 +812,18 @@
       "css": [
         "content_scripts/jeuneAfrique.css"
       ]
+    },
+        {
+      "matches": [
+        "https://www.leberry.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/leberry.js"
+      ],
+      "css": [
+        "content_scripts/leberry.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
# Ajout Le Berry Republicain
#354 

MutationObserver pour gerer les updates de dom et navigation à la react.
Methode watchUrlChanges  copiée du fichier challenges.js



## tests 
- libreWolf 140.0.2-1  + compte europresse BNF
- article du jour et de la veille ne sont pas sur europresse. Mais les articles du vendredi sont trouvables.
https://www.leberry.fr/auxerre-89000/actualites/a-vezelay-avallon-nevers-chateaudun-julien-cohen-enchaine-l-achat-de-tresors-patrimoniaux-je-pense-que-je-ne-m-arreterai-jamais_14716114/