### PR TITLE
Fix lemonde.fr

### DIFF
--- a/ophirofox/content_scripts/lemonde.js
+++ b/ophirofox/content_scripts/lemonde.js
@@ -21,14 +21,14 @@ async function createLink() {
 }
 
 async function onLoad() {
-    const statusElem = document.querySelector(".article__status");
+    const statusElem = document.querySelector(".ds-article-status__text");
     if (statusElem) {
         statusElem.appendChild(await createLink());
     }
-    const paywallElem = document.querySelector(".paywall-04__cta");
+    const paywallElem = document.querySelector(".lmd-paywall__cta");
     if (paywallElem) {
         const link = await createLink();
-        link.className = "lmd-btn lmd-btn--l lmd-btn--premium paywall-04__cta";
+        link.className = "lmd-btn lmd-btn--l lmd-btn--premium lmd-paywall__cta";
         paywallElem.parentNode.insertBefore(link, paywallElem);
     }
 }


### PR DESCRIPTION
Les classes HTML des deux boutons `Article réservé aux abonnés` et `Je m'abonne` ont changé.
Merci pour cette extension et la maintenance associée !