### PR TITLE
Fix univ-littoral.fr AUTH_URL

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1120,7 +1120,7 @@
         },
         {
           "name": "Université du Littoral Côte d'Opale (UCLO)",
-          "AUTH_URL": "http://ezproxy.univ-littoral.fr/login?url=http://nouveau.europresse.com/access/ip/default.aspx?un=dunkerqueT_1"
+          "AUTH_URL": "https://ezproxy.univ-littoral.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=dunkerqueT_1"
         },
         {
           "name": "Université de Lorraine",

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1119,7 +1119,7 @@
           "AUTH_URL": "https://ezproxy.unilim.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=U031697T_1"
         },
         {
-          "name": "Université du Littoral Côte d'Opale (UCLO)",
+          "name": "Université du Littoral Côte d'Opale (ULCO)",
           "AUTH_URL": "https://ezproxy.univ-littoral.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=dunkerqueT_1"
         },
         {


### PR DESCRIPTION
Hello,

Depuis la mise en place de la nouvelle plateforme CAS sur l'auth des ressources de l'Université du Littoral (ULCO), la redirection ne fonctionnait plus ("application non autorisée" via le CAS)

Après tests en env de dev, les modifications de cette PR semblent fixer l'erreur.

