### PR TITLE
add the economist (UK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Voici la liste triée par ordre alphabétique :
   - [PressReader (nécessite un abonnement BNF)](https://www.pressreader.com/fr)
   - [Sudinfo (Belgique)](https://www.sudinfo.be/)
   - [Trends-Tendances (Belgique)](https://trends.levif.be/)
+  - [The Economist (Royaume-Uni)](https://www.economist.com/)
 
 Vous pouvez proposer d'autres sites Web de médias en ouvrant une [demande ici-même](https://github.com/lovasoa/ophirofox/issues).
 

--- a/ophirofox/content_scripts/theEconomist.css
+++ b/ophirofox/content_scripts/theEconomist.css
@@ -1,0 +1,8 @@
+.ophirofox-europresse{
+    background: #1f2e7a;
+    color: #fff;
+    border: 0.125rem solid transparent;
+    border-radius: 1.25rem;
+    align-items: center;
+    padding: 0.375rem 1rem;
+ }

--- a/ophirofox/content_scripts/theEconomist.js
+++ b/ophirofox/content_scripts/theEconomist.js
@@ -1,0 +1,27 @@
+function extractKeywords() {
+    return document
+        .querySelector("meta[property='og:title']")
+        .getAttribute("content");
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+function findPremiumBanner() {
+    const anchor = document.querySelector('#regwall-container');
+    if (!anchor) {
+        return;
+    }
+    return anchor;
+}
+
+async function onLoad() {
+    const premiumBanner = findPremiumBanner();
+    if (!premiumBanner) return;
+    premiumBanner.parentElement.before(await createLink());
+    document.querySelector('h1').after(await createLink())
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -815,7 +815,7 @@
         "content_scripts/jeuneAfrique.css"
       ]
     },
-        {
+    {
       "matches": [
         "https://www.leberry.fr/*"
       ],
@@ -825,6 +825,18 @@
       ],
       "css": [
         "content_scripts/leberry.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://www.economist.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/theEconomist.js"
+      ],
+      "css": [
+        "content_scripts/theEconomist.css"
       ]
     }
   ],


### PR DESCRIPTION
# Ajout de 'The Economist' (UK)
#368 

testé avec firefox (fork librewolf) et abonnement BNF.

lien et redirection fonctionne bien mais ya un truc étrange sur les articles liés coté europress :  ya juste 2 - 3 lignes et un lien qui renvoi vers le site the economist.  Je sais pas si ça vaut la peine de l'ajouter du coup.

### exemple
https://www.economist.com/united-states/2025/09/04/the-rules-for-defending-democracy-under-donald-trump
Et coté europress : 
> The Economist (web site ref.) - Economist
>September 5, 2025 250 mots
The rules for defending democracy under Donald Trump
>
>For his government, invading the Capitol is honourable, but burning the flag goes too far Illustration: David Simonds Sep 4th 2025|5 min read America was still fighting fascism overseas in...[ Voir l'article](https://www.economist.com/united-states/2025/09/04/the-rules-for-defending-democracy-under-donald-trump)
>
>Ce document référence un lien URL de site non hébergé par Cision.