### PR TITLE
feat: add support for lettreaudiovisuel.com

### DIFF
--- a/ophirofox/content_scripts/lettreaudiovisuel.css
+++ b/ophirofox/content_scripts/lettreaudiovisuel.css
@@ -1,0 +1,10 @@
+.ophirofox-europresse {
+  background: #2b4c96;
+  color: #fff;
+  font-weight: 600;
+  padding: 6px 16px 6px 16px;
+  border-radius: 5px;
+  text-decoration: none;
+  font-size: 0.98em;
+  display: inline-block;
+}

--- a/ophirofox/content_scripts/lettreaudiovisuel.js
+++ b/ophirofox/content_scripts/lettreaudiovisuel.js
@@ -1,0 +1,19 @@
+function extractKeywords() {
+    return document.querySelector("h1").textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.classList.add("is-btn");
+    return a;
+}
+
+async function onLoad() {    
+    const paywall = document.querySelector(".mepr-unauthorized-message");
+    paywall.before(await createLink());
+
+    const header = document.querySelector("h1");
+    header.after(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -390,6 +390,18 @@
     },
     {
       "matches": [
+        "https://lettreaudiovisuel.com/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/lettreaudiovisuel.js"
+      ],
+      "css": [
+        "content_scripts/lettreaudiovisuel.css"
+      ]
+    },
+    {
+      "matches": [
         "https://www.lexpress.fr/*"
       ],
       "js": [


### PR DESCRIPTION
Ajout du support du site de La Lettre de l'Audiovisuel
<img width="1218" height="601" alt="image" src="https://github.com/user-attachments/assets/8887ce4e-c490-49a2-8a2b-b6b5203a696e" />
<img width="703" height="460" alt="image" src="https://github.com/user-attachments/assets/92b92a25-3890-47c3-ae40-09232443c243" />
<img width="272" height="269" alt="image" src="https://github.com/user-attachments/assets/02ab328b-6795-451a-ab85-f738dc70be4f" />
