### PR TITLE
fix: missing data_collection_permission for Mozilla

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -846,7 +846,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{cfd3c5c2-31ec-4c1b-a28e-df38357d02d9}",
-      "update_url": "https://github.com/lovasoa/ophirofox/releases/latest/download/update_manifest.json"
+      "update_url": "https://github.com/lovasoa/ophirofox/releases/latest/download/update_manifest.json",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     },
     "ophirofox_metadata": {
       "partners": [


### PR DESCRIPTION
> Beginning November 3rd 2025, all new extensions will be required to adopt the Firefox built-in data collection consent system. Extensions will need to state if and what data they collect or transmit.

https://mzl.la/firefox-builtin-data-consent

Je ne pense pas que la permission `websiteContent` ne s'applique vu qu'il n'y a pas de collection de données personnelles ?