### PR TITLE
feat: support for La Nouvelle République

### DIFF
--- a/ophirofox/content_scripts/lanouvellerepublique.css
+++ b/ophirofox/content_scripts/lanouvellerepublique.css
@@ -1,0 +1,6 @@
+.ophirofox-europresse {
+  background-color: #f1c84b;
+  padding: 3px 15px;
+  border-radius: 2px;
+  margin-right: 5px;
+}

--- a/ophirofox/content_scripts/lanouvellerepublique.js
+++ b/ophirofox/content_scripts/lanouvellerepublique.js
@@ -1,0 +1,15 @@
+function extractKeywords() {
+    return document.querySelector('h1').textContent;
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    return a;
+}
+
+async function onLoad() {
+    const head = document.querySelector('.nr-abo-container');
+    head.after(await createLink()); 
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -841,6 +841,18 @@
       "css": [
         "content_scripts/theEconomist.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.lanouvellerepublique.fr/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/lanouvellerepublique.js"
+      ],
+      "css": [
+        "content_scripts/lanouvellerepublique.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Les titres ne sont pas 100% identiques entre le site et ce qu'il y a sur Europresse (différence entre la version web & papier je suppose), donc on a quelques cas où on ne trouve rien alors que les articles sont bien indexés. Mais le titre papier ne semble être nul part présent sur le site, donc faute de mieux ...

<img width="1211" height="340" alt="image" src="https://github.com/user-attachments/assets/e2b90abf-1ad8-44d4-83b0-5497217abade" />
<img width="325" height="287" alt="image" src="https://github.com/user-attachments/assets/2a02aa65-688f-4885-a9ae-3e2dd16cb996" />

<img width="1195" height="324" alt="image" src="https://github.com/user-attachments/assets/38679737-407c-4cbd-992a-1efd1eec2f59" />
<img width="306" height="305" alt="image" src="https://github.com/user-attachments/assets/134ab320-3d4c-4e0d-8ff1-fbbe6c1a630c" />

Resolves #300 
