### PR TITLE
Renomme Ecole des Ponts ParisTech en Ecole nationale des ponts et chaussées - Institut Polytechnique de Paris

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1022,7 +1022,7 @@
           "AUTH_URL": "https://docelec.insa-lyon.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=INSAT_3"
         },
         {
-          "name": "École des Ponts ParisTech",
+          "name": "Ecole nationale des ponts et chaussées - Institut Polytechnique de Paris",
           "AUTH_URL": "https://extranet.enpc.fr/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=umiv"
         },
         {


### PR DESCRIPTION
Fix #405 