### PR TITLE
Tentative fix sur Linux (Simplify content script injection logic)

### DIFF
--- a/ophirofox/background.js
+++ b/ophirofox/background.js
@@ -100,18 +100,11 @@ async function registerContentScripts(content_script) {
 async function injectEuropressUsingScripting(matches) {
   const content_script = { ...europresse_content_script, matches, id: "europresse" };
   
-  try {
-    const existing = await chrome.scripting.getRegisteredContentScripts({ ids: ["europresse"] });
-    if (existing.length > 0) {
-      await unregisterContentScripts();
-    }
-  } catch (err) {
-    console.log("Nothing to unregister:", err);
-  }
-
+  await unregisterContentScripts();
   await registerContentScripts(content_script);
   console.log("Injected Europress using scripting", matches);
 }
+
 
 /**
  * Fonction principale pour injecter les scripts Europresse


### PR DESCRIPTION
Simplify content script injection logic
Removed redundant check for existing content scripts before unregistering.