### PR TITLE
Correction du code Europresse pour l'Université Gustave Eiffel

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1174,7 +1174,7 @@
         },
         {
           "name": "Université Gustave Eiffel",
-          "AUTH_URL": "https://univ-eiffel.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000030T_5"
+          "AUTH_URL": "https://univ-eiffel.idm.oclc.org/login?url=https://nouveau.europresse.com/access/ip/default.aspx?un=D000030T_1"
         },
         {
           "name": "Université Le Havre Normandie",


### PR DESCRIPTION
Source : https://bu.univ-gustave-eiffel.fr/accueil/ressources_electroniques_a_z
