### PR TITLE
fix(alternatives-economiques): mise à jour du sélecteur de paywall 

### DIFF
--- a/ophirofox/content_scripts/alternatives-economiques.js
+++ b/ophirofox/content_scripts/alternatives-economiques.js
@@ -6,28 +6,19 @@ const BNF_ALTERNATIVESECONOMIQUES_LOGIN_URL = "https://bnf.idm.oclc.org/login?ur
  * @description create link <a> to BNF mirror
  */
 function createLink() {
-    const span = document.createElement("span");
-    span.textContent = "Lire avec BNF";
-    span.className = "sub-stamp-component etiquette ophirofox-europresse";
     const a = document.createElement("a");
+    a.textContent = "Lire avec BNF";
     a.href = BNF_ALTERNATIVESECONOMIQUES_LOGIN_URL;
-    a.appendChild(span);
     return a;
 }
 
 /**
  * @description check DOM for paywall iframe
- * @return {HTMLElement[]} The paywall iframe elements
  */
 function findPremiumBanner() {
-    const paywall = document.querySelector("iframe#temp-paywall");
+    const paywall = document.querySelector("iframe#p3-paywall");
     if (!paywall) return [];
     return [paywall];
-}
-
-/** @return {boolean} true si le bouton BNF est déjà dans le DOM */
-function bnfLinkAlreadyPresent() {
-    return !!document.querySelector("a.ophirofox-europresse");
 }
 
 async function handleAlternativesEconomiquesMirror(config) {
@@ -38,11 +29,9 @@ async function handleAlternativesEconomiquesMirror(config) {
         await chrome.storage.sync.get(['ophirofox_alternativeseconomiques_article']);
 
     if (!articlePath) {
-        // If we're directly on the mirror with no stored article, nothing to do
         return;
     }
 
-    // Redirect to the stored article on the mirror
     console.log("[ophirofox][ae-mirror] redirect to:", articlePath);
     chrome.storage.sync.remove(["ophirofox_alternativeseconomiques_article"]);
     window.location.pathname = articlePath;
@@ -51,32 +40,23 @@ async function handleAlternativesEconomiquesMirror(config) {
 async function handleAlternativesEconomiques(config) {
     console.log("[ophirofox][ae] checking for premium banner");
 
-    if (bnfLinkAlreadyPresent()) return;
-
     const reserve = findPremiumBanner();
     if (!reserve?.length) return;
 
-    console.log("[ophirofox][ae] premium banner found, injecting link");
+    console.log("[ophirofox][ae] premium banner found, storing article path");
     chrome.storage.sync.set({
         "ophirofox_alternativeseconomiques_article": new URL(window.location).pathname
     });
 
-    for (const balise of reserve) {
-        const link = createLink();
-        balise.parentElement.insertBefore(link, balise);
-        console.log("[ophirofox][ae] link injected —", link);
-        console.log("[ophirofox][ae] find it with: document.querySelector('a.ophirofox-europresse')");
-    }
+    injectRubriquesBnfLink();
 }
 
-/** @description watch for the paywall iframe to appear and inject the BNF link */
+/** @description watch for the paywall iframe to appear */
 function watchForPaywall(config) {
-    // Tentative immédiate au cas où l'iframe est déjà là
     handleAlternativesEconomiques(config).catch(console.error);
 
-    // Observe le DOM jusqu'à ce que iframe#temp-paywall apparaisse
     const observer = new MutationObserver(() => {
-        if (document.querySelector("iframe#temp-paywall")) {
+        if (document.querySelector("iframe#p3-paywall")) {
             console.log("[ophirofox][ae] paywall iframe detected via observer");
             handleAlternativesEconomiques(config).catch(console.error);
             observer.disconnect();
@@ -84,25 +64,43 @@ function watchForPaywall(config) {
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    // Filet de sécurité : arrêter l'observer après 30s
     setTimeout(() => observer.disconnect(), 30000);
 }
 
-/** @description check for BNF users. If yes, create link button */
+/** @description inject BNF link as first child inside .article-header__rubriques */
+async function injectRubriquesBnfLink() {
+    const tryInject = () => {
+        const rubriques = document.querySelector(".article-header__rubriques");
+        if (!rubriques) return false;
+        if (rubriques.querySelector(".ophirofox-europresse")) return true;
+        const link = createLink();
+        link.className = "ophirofox-europresse";
+        rubriques.insertBefore(link, rubriques.firstChild);
+        return true;
+    };
+
+    if (tryInject()) return;
+
+    const observer = new MutationObserver(() => {
+        if (tryInject()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    setTimeout(() => observer.disconnect(), 30000);
+}
+
 async function onLoad() {
     console.log("[ophirofox][ae] onLoad");
+
     const config = await configurationsSpecifiques(['BNF']);
     if (!config) {
         console.log("[ophirofox][ae] no BNF config found, aborting");
         return;
     }
     const currentPage = new URL(window.location);
-    console.log("[ophirofox][ae] currentPage.host:", currentPage.host, "| AUTH_URL_ALTERNATIVESECONOMIQUES:", config.AUTH_URL_ALTERNATIVESECONOMIQUES);
     if (currentPage.host == config.AUTH_URL_ALTERNATIVESECONOMIQUES) {
         console.log("[ophirofox][ae] on mirror, running handleAlternativesEconomiquesMirror");
         handleAlternativesEconomiquesMirror(config);
     } else {
-        console.log("[ophirofox][ae] on original site, running handleAlternativesEconomiques");
         watchForPaywall(config);
     }
 }


### PR DESCRIPTION
- iframe#temp-paywall → iframe#p3-paywall
- Bouton 'Lire avec BNF' placé en premier enfant dans .article-header__rubriques
- Bouton visible uniquement si l'article est payant ET l'utilisateur a BNF

Ceci fix #404 