### PR TITLE
feat(24heures): ajout du support 24heures.ch (Lire sur Europresse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Voici la liste triée par ordre alphabétique :
   - [Le Berry Républicain](https://www.leberry.fr/)
   - [Le Soir (Belgique)](https://www.lesoir.be)
   - [Le Temps (Suisse)](https://www.letemps.ch/)
+  - [24 heures (Suisse)](https://www.24heures.ch/)
   - [Le Vif (Belgique)](https://www.levif.be/)
   - [PressReader (nécessite un abonnement BNF)](https://www.pressreader.com/fr)
   - [Sudinfo (Belgique)](https://www.sudinfo.be/)

--- a/ophirofox/content_scripts/24heures.css
+++ b/ophirofox/content_scripts/24heures.css
@@ -1,0 +1,12 @@
+.ophirofox-europresse {
+    display: inline-block;
+    margin-right: .5rem;
+    padding: .2rem .6rem;
+    font-weight: 600;
+    font-size: 1.2rem;
+    font-family: var(--font-libre-franklin);
+    line-height: 1.6rem;
+    letter-spacing: .025rem;
+    background: #ffe404;
+    color: black;
+}

--- a/ophirofox/content_scripts/24heures.js
+++ b/ophirofox/content_scripts/24heures.js
@@ -1,0 +1,25 @@
+function extractKeywords() {
+    const title = document.querySelector("h1, .titleheader");
+    return title?.textContent?.trim();
+}
+
+async function createLink() {
+    const a = await ophirofoxEuropresseLink(extractKeywords());
+    a.classList.add("ophirofox-europresse");
+    return a;
+}
+
+function findPremiumBanner() {
+    const premium = document.querySelector("span.premium");
+    if (!premium?.textContent.includes("Abo")) return null;
+    return premium;
+}
+
+async function onLoad() {
+    if (window.location.pathname === "/") return;
+    const premium = findPremiumBanner();
+    if (!premium) return;
+    premium.before(await createLink());
+}
+
+onLoad().catch(console.error);

--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -899,6 +899,18 @@
       "css": [
         "content_scripts/lagazettedescommunes.css"
       ]
+    },
+    {
+      "matches": [
+        "https://www.24heures.ch/*"
+      ],
+      "js": [
+        "content_scripts/config.js",
+        "content_scripts/24heures.js"
+      ],
+      "css": [
+        "content_scripts/24heures.css"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Bouton 'Lire sur Europresse' inséré avant le badge Abo dans .ArticleTitleHeader

Fix #466 