### PR TITLE
Ajout de Vallée Sud Médiathèques

### DIFF
--- a/ophirofox/manifest.json
+++ b/ophirofox/manifest.json
@@ -1493,6 +1493,11 @@
           "name": "Médiathèques de Rennes Métropole",
           "HTTP_REFERER": "https://www.lesmediatheques-rennesmetropole.fr/",
           "AUTH_URL": "https://nouveau.europresse.com/access/httpref/default.aspx?un=CARMU_2"
+        },
+        {
+          "name": "Vallée Sud Médiathèques",
+          "HTTP_REFERER": "https://mediatheques.valleesud.fr/",
+          "AUTH_URL": "https://nouveau.europresse.com/access/httpref/default.aspx?un=U032788U_2"
         }
       ]
     }


### PR DESCRIPTION
Ajoute **Vallée Sud Médiathèques** à la liste des partenaires Europresse.

Il s'agit d'un portail à authentification par référent HTTP (`access/httpref`), comme les Médiathèques d'Antony, de Rennes Métropole ou les Bibliothèques du Val d'Oise. L'entrée définit donc `HTTP_REFERER` sur le domaine du portail (`https://mediatheques.valleesud.fr/`) pour que le référent soit correctement réécrit par le background script.

```json
{
  "name": "Vallée Sud Médiathèques",
  "HTTP_REFERER": "https://mediatheques.valleesud.fr/",
  "AUTH_URL": "https://nouveau.europresse.com/access/httpref/default.aspx?un=U032788U_2"
}
```

L'`AUTH_URL` pointe directement vers `nouveau.europresse.com` (déjà couvert par les permissions existantes), aucune nouvelle permission n'est donc nécessaire.

Testé et fonctionnel : le lien redirige bien vers Europresse et donne accès à la recherche.
