### PR TITLE
Fix La Gazette des communes paywall link

### DIFF
--- a/ophirofox/content_scripts/lagazettedescommunes.css
+++ b/ophirofox/content_scripts/lagazettedescommunes.css
@@ -1,3 +1,4 @@
 .ophirofox-europresse {
-    line-height: 50px;
+    line-height: inherit;
+    text-decoration: underline;
 }

--- a/ophirofox/content_scripts/lagazettedescommunes.js
+++ b/ophirofox/content_scripts/lagazettedescommunes.js
@@ -1,23 +1,23 @@
+const PAYWALL_LABEL_SELECTOR = ".c-paywall-label";
+
 function extractKeywords() {
-    return document.querySelector("h1").textContent;
+    return document.querySelector("h1")?.textContent;
 }
 
 async function createLink() {
-    const a = await ophirofoxEuropresseLink(extractKeywords());
-    a.classList.add("buttonTypeA", "buttonTypeA--1");
-    return a;
+    return await ophirofoxEuropresseLink(extractKeywords());
 }
 
 function findPremiumBanner() {
-    const title = document.querySelector("h1");
-    if (!title) return null;
-    return title.parentElement.querySelector(".notYet") ? title : null;
+    return [...document.querySelectorAll(PAYWALL_LABEL_SELECTOR)]
+        .find((label) => label.textContent.includes("Réservé aux abonnés"));
 }
 
 async function onLoad() {
+    if (document.querySelector(".ophirofox-europresse")) return;
     const premiumBanner = findPremiumBanner();
     if (!premiumBanner) return;
-    premiumBanner.after(await createLink());
+    premiumBanner.append(document.createTextNode(" • "), await createLink());
 }
 
 onLoad().catch(console.error);


### PR DESCRIPTION
## Summary
- detect the new La Gazette des communes paywall label
- inject the Europresse link inline in the subscription label with a bullet separator
- adjust link styling for inline display

## Test
- node --check ophirofox/content_scripts/lagazettedescommunes.js